### PR TITLE
According to the usage, you should be able to pass the name to LOG().

### DIFF
--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -44,6 +44,10 @@ class LOG:
     _loggers = {}
 
     @classmethod
+    def __init__(cls, name='OVOS'):
+        cls.name = name
+
+    @classmethod
     def init(cls, config=None):
 
         from ovos_config.meta import get_xdg_base


### PR DESCRIPTION
See those :
https://github.com/OpenVoiceOS/ovos-utils/blob/c9b1b560dab02d13a77bd9c1f3ad788e65fb9c13/ovos_utils/log.py#L31
https://github.com/OpenVoiceOS/ovos-core/blob/c5c1f37556173afeb3790514cafabae310e218c1/mycroft/util/process_utils.py#L44

WIthout this change, the cli commmand `log level DEBUG` fails miserably.