### PR TITLE
Implement module_property decorator with unit test

### DIFF
--- a/ovos_utils/system.py
+++ b/ovos_utils/system.py
@@ -318,3 +318,28 @@ def has_screen():
         except ImportError:
             pass
     return have_display
+
+
+def module_property(func):
+    """
+    Decorator to turn module functions into properties.
+    Function names must be prefixed with an underscore.
+    :param func: function to decorate
+    """
+    import sys
+    module = sys.modules[func.__module__]
+
+    def fallback_getattr(name):
+        raise AttributeError(
+            f"module '{module.__name__}' has no attribute '{name}'")
+
+    default_getattr = getattr(module, '__getattr__', fallback_getattr)
+
+    def patched_getattr(name):
+        if f'_{name}' == func.__name__:
+            return func()
+        return default_getattr(name)
+
+    module.__getattr__ = patched_getattr
+    return func
+

--- a/test/unittests/test_system.py
+++ b/test/unittests/test_system.py
@@ -1,0 +1,105 @@
+import unittest
+
+
+class TestSystem(unittest.TestCase):
+    def test_is_running_from_module(self):
+        from ovos_utils.system import is_running_from_module
+        self.assertFalse(is_running_from_module("mycroft"))
+        self.assertTrue(is_running_from_module("unittest"))
+
+    def test_ntp_sync(self):
+        # TODO
+        pass
+
+    def test_system_shutdown(self):
+        # TODO
+        pass
+
+    def test_system_reboot(self):
+        # TODO
+        pass
+
+    def test_ssh_enable(self):
+        # TODO
+        pass
+
+    def test_ssh_disable(self):
+        # TODO
+        pass
+
+    def test_restart_mycroft_service(self):
+        # TODO
+        pass
+
+    def test_restart_service(self):
+        # TODO
+        pass
+
+    def test_enable_service(self):
+        # TODO
+        pass
+
+    def test_disable_service(self):
+        # TODO
+        pass
+
+    def test_check_service_active(self):
+        # TODO
+        pass
+
+    def test_set_root_path(self):
+        from ovos_utils.system import set_root_path, _USER_DEFINED_ROOT
+        set_root_path("test")
+        self.assertEqual(_USER_DEFINED_ROOT, "test")
+        set_root_path("mycroft")
+        self.assertEqual(_USER_DEFINED_ROOT, "mycroft")
+        set_root_path(None)
+        self.assertIsNone(_USER_DEFINED_ROOT)
+
+    def test_find_root_from_sys_path(self):
+        # TODO
+        pass
+
+    def test_find_root_from_sitepackages(self):
+        # TODO
+        pass
+
+    def test_search_mycroft_core_location(self):
+        # TODO
+        pass
+
+    def test_get_desktop_environment(self):
+        # TODO
+        pass
+
+    def test_is_process_running(self):
+        # TODO
+        pass
+
+    def test_find_executable(self):
+        # TODO
+        pass
+
+    def test_is_installed(self):
+        # TODO
+        pass
+
+    def test_has_screen(self):
+        # TODO
+        pass
+
+    def test_module_property(self):
+        import sys
+        from ovos_utils.system import module_property
+
+        test_val = True
+
+        @module_property
+        def _mock_property():
+            return test_val
+
+        test_module = sys.modules[self.__module__]
+        self.assertTrue(test_module.mock_property)
+
+        test_val = False
+        self.assertFalse(test_module.mock_property)

--- a/test/unittests/test_system.py
+++ b/test/unittests/test_system.py
@@ -48,12 +48,15 @@ class TestSystem(unittest.TestCase):
         pass
 
     def test_set_root_path(self):
-        from ovos_utils.system import set_root_path, _USER_DEFINED_ROOT
+        from ovos_utils.system import set_root_path
         set_root_path("test")
+        from ovos_utils.system import _USER_DEFINED_ROOT
         self.assertEqual(_USER_DEFINED_ROOT, "test")
         set_root_path("mycroft")
+        from ovos_utils.system import _USER_DEFINED_ROOT
         self.assertEqual(_USER_DEFINED_ROOT, "mycroft")
         set_root_path(None)
+        from ovos_utils.system import _USER_DEFINED_ROOT
         self.assertIsNone(_USER_DEFINED_ROOT)
 
     def test_find_root_from_sys_path(self):


### PR DESCRIPTION
Porting decorator from [neon-utils](https://github.com/NeonGeckoCom/neon-utils/blob/dev/neon_utils/decorators.py#L32) to address feedback in [this OCP PR](https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/pull/56)