### PR TITLE
Bump ovos-config dependency cleanup module init

### DIFF
--- a/ovos_utils/__init__.py
+++ b/ovos_utils/__init__.py
@@ -20,6 +20,7 @@ from time import sleep
 
 import kthread
 
+# TODO: Deprecate below imports
 from ovos_utils.file_utils import resolve_ovos_resource_file, resolve_resource_file
 from ovos_utils.network_utils import get_ip, get_external_ip, is_connected_dns, is_connected_http, is_connected
 

--- a/ovos_utils/dialog.py
+++ b/ovos_utils/dialog.py
@@ -5,7 +5,7 @@ from os.path import join
 from pathlib import Path
 
 from ovos_utils.bracket_expansion import expand_options
-from ovos_config.config import read_mycroft_config
+from ovos_config.config import Configuration
 from ovos_utils.file_utils import resolve_resource_file
 from ovos_utils.lang import translate_word
 from ovos_utils.log import LOG
@@ -146,7 +146,7 @@ def get_dialog(phrase, lang=None, context=None):
 
     if not lang:
         try:
-            conf = read_mycroft_config()
+            conf = Configuration()
             lang = conf.get('lang')
         except FileNotFoundError:
             lang = "en-us"

--- a/ovos_utils/file_utils.py
+++ b/ovos_utils/file_utils.py
@@ -103,8 +103,8 @@ def resolve_resource_file(res_name, root_path=None, config=None):
         str: path to resource or None if no resource found
     """
     if config is None:
-        from ovos_config.config import read_mycroft_config
-        config = read_mycroft_config()
+        from ovos_config.config import Configuration
+        config = Configuration()
 
     # First look for fully qualified file (e.g. a user setting)
     if os.path.isfile(res_name):

--- a/ovos_utils/fingerprinting.py
+++ b/ovos_utils/fingerprinting.py
@@ -4,7 +4,6 @@ from enum import Enum
 from os.path import join, isfile
 from ovos_utils.system import is_installed, is_running_from_module, has_screen, \
     get_desktop_environment, search_mycroft_core_location, is_process_running
-from ovos_config.meta import is_using_xdg
 
 
 class MycroftPlatform(str, Enum):
@@ -28,8 +27,8 @@ def detect_platform():
 
 def get_config_fingerprint(config=None):
     if not config:
-        from ovos_config.config import read_mycroft_config
-        config = read_mycroft_config()
+        from ovos_config.config import Configuration
+        config = Configuration()
     conf = config
     listener_conf = conf.get("listener", {})
     skills_conf = conf.get("skills", {})
@@ -80,9 +79,7 @@ def get_fingerprint():
 
 
 def core_supports_xdg():
-    if any((is_holmes(), is_chatterbox_core())):
-        return True
-    return is_using_xdg()
+    return True  # no longer optional
 
 
 def get_mycroft_version():

--- a/ovos_utils/gui.py
+++ b/ovos_utils/gui.py
@@ -7,6 +7,7 @@ from ovos_utils import resolve_ovos_resource_file, resolve_resource_file
 from ovos_utils.log import LOG
 from ovos_utils.messagebus import wait_for_reply, get_mycroft_bus, Message
 from ovos_utils.system import is_installed, has_screen, is_process_running
+from ovos_config import Configuration
 
 
 def can_display():
@@ -460,7 +461,7 @@ class GUIInterface:
     """
 
     def __init__(self, skill_id, bus=None, remote_server=None, config=None):
-        self.config = config or {}
+        self.config = config or Configuration().get("gui", {})
         if remote_server:
             self.config["remote-server"] = remote_server
         self._bus = bus

--- a/ovos_utils/messagebus.py
+++ b/ovos_utils/messagebus.py
@@ -5,7 +5,7 @@ from threading import Event
 
 from mycroft_bus_client import MessageBusClient
 from mycroft_bus_client.message import dig_for_message, Message
-from ovos_config.config import read_mycroft_config
+from ovos_config.config import Configuration
 from ovos_config.locale import get_default_lang
 from pyee import BaseEventEmitter
 
@@ -150,8 +150,7 @@ def get_mycroft_bus(host: str = None, port: int = None, route: str = None,
     """
     Returns a connection to the mycroft messagebus
     """
-    from ovos_config.config import read_mycroft_config
-    config = read_mycroft_config().get('websocket') or dict()
+    config = Configuration().get('websocket') or dict()
     host = host or config.get('host') or _DEFAULT_WS_CONFIG['host']
     port = port or config.get('port') or _DEFAULT_WS_CONFIG['port']
     route = route or config.get('route') or _DEFAULT_WS_CONFIG['route']
@@ -553,7 +552,7 @@ class BusFeedProvider:
                 name(str): name identifier for .conf settings
                 bus (WebsocketClient): mycroft messagebus websocket
         """
-        config = config or read_mycroft_config()
+        config = config or Configuration()
         self.trigger_message = trigger_message
         self.name = name or self.__class__.__name__
         self.bus = bus or get_mycroft_bus()
@@ -695,7 +694,7 @@ class BusFeedConsumer:
         self.query_message.context["source"] = self.name
         self.name = name or self.__class__.__name__
         self.bus = bus or get_mycroft_bus()
-        config = config or read_mycroft_config()
+        config = config or Configuration()
         self.config = config.get(self.name, {})
         self.timeout = timeout
         self.query = None

--- a/ovos_utils/network_utils.py
+++ b/ovos_utils/network_utils.py
@@ -4,10 +4,7 @@ import requests
 
 # backwards compat - was only out there for a couple alpha version
 # TODO - remove next stable
-try:
-    from ovos_utils.process_utils import RuntimeRequirements as NetworkRequirements
-except:
-    pass  # circular import introduced here, ovos_config importts network_utils, process_utils imports ovos_config
+from ovos_utils.process_utils import RuntimeRequirements as NetworkRequirements
 
 from ovos_utils.log import LOG
 

--- a/ovos_utils/process_utils.py
+++ b/ovos_utils/process_utils.py
@@ -22,7 +22,6 @@ from signal import signal, SIGKILL, SIGINT, SIGTERM, \
 from threading import Event
 from time import sleep, monotonic
 
-from ovos_config.meta import get_xdg_base
 
 from ovos_utils.file_utils import get_temp_path
 from ovos_utils.log import LOG
@@ -291,7 +290,7 @@ class PIDLock:  # python 3+ 'class Lock'
     of the same type is started, this class will 'attempt' to stop the
     previously running process and then change the process ID in the lock file.
     """
-
+    from ovos_config.meta import get_xdg_base
     #
     # Class constants
     DIRECTORY = get_temp_path(get_xdg_base())

--- a/ovos_utils/process_utils.py
+++ b/ovos_utils/process_utils.py
@@ -289,13 +289,16 @@ class PIDLock:  # python 3+ 'class Lock'
     of the same type is started, this class will 'attempt' to stop the
     previously running process and then change the process ID in the lock file.
     """
-    from ovos_config.meta import get_xdg_base
-    from ovos_utils.file_utils import get_temp_path
+    @classmethod
+    def init(cls):
+        from ovos_config.meta import get_xdg_base
+        from ovos_utils.file_utils import get_temp_path
+        cls.DIRECTORY = cls.DIRECTORY or get_temp_path(get_xdg_base())
     #
     # Class constants
-    DIRECTORY = get_temp_path(get_xdg_base())
+    DIRECTORY = None
     FILE = '/{}.pid'
-    LOG.info(f"Create PIDLock for: {get_xdg_base()}")
+    LOG.info(f"Create PIDLock in: {DIRECTORY}")
 
     #
     # Constructor
@@ -307,6 +310,7 @@ class PIDLock:  # python 3+ 'class Lock'
         service: Text string.  The name of the service application
         to be locked (ie: skills, voice)
         """
+        PIDLock.init()
         super(PIDLock, self).__init__()  # python 3+ 'super().__init__()'
         self.__pid = os.getpid()  # PID of this application
         self.path = PIDLock.DIRECTORY + PIDLock.FILE.format(service)

--- a/ovos_utils/process_utils.py
+++ b/ovos_utils/process_utils.py
@@ -23,7 +23,6 @@ from threading import Event
 from time import sleep, monotonic
 
 
-from ovos_utils.file_utils import get_temp_path
 from ovos_utils.log import LOG
 
 
@@ -291,10 +290,12 @@ class PIDLock:  # python 3+ 'class Lock'
     previously running process and then change the process ID in the lock file.
     """
     from ovos_config.meta import get_xdg_base
+    from ovos_utils.file_utils import get_temp_path
     #
     # Class constants
     DIRECTORY = get_temp_path(get_xdg_base())
     FILE = '/{}.pid'
+    LOG.info(f"Create PIDLock for: {get_xdg_base()}")
 
     #
     # Constructor

--- a/ovos_utils/signal.py
+++ b/ovos_utils/signal.py
@@ -23,8 +23,8 @@ def get_ipc_directory(domain=None, config=None):
         str: a path to the IPC directory
     """
     if config is None:
-        from ovos_config.config import read_mycroft_config
-        config = read_mycroft_config()
+        from ovos_config.config import Configuration
+        config = Configuration()
     path = config.get("ipc_path")
     if not path:
         # If not defined, use /tmp/mycroft/ipc

--- a/ovos_utils/skills/__init__.py
+++ b/ovos_utils/skills/__init__.py
@@ -1,4 +1,4 @@
-from ovos_config.config import read_mycroft_config, update_mycroft_config
+from ovos_config.config import Configuration, update_mycroft_config
 from ovos_utils.messagebus import wait_for_reply
 from ovos_utils.skills.locations import get_default_skills_directory, get_installed_skill_ids
 from ovos_utils.log import LOG
@@ -39,7 +39,7 @@ def skills_loaded(bus=None):
 
 
 def blacklist_skill(skill, config=None):
-    config = config or read_mycroft_config()
+    config = config or Configuration()
     skills_config = config.get("skills", {})
     blacklisted_skills = skills_config.get("blacklisted_skills", [])
     if skill not in blacklisted_skills:
@@ -55,7 +55,7 @@ def blacklist_skill(skill, config=None):
 
 
 def whitelist_skill(skill, config=None):
-    config = config or read_mycroft_config()
+    config = config or Configuration()
     skills_config = config.get("skills", {})
     blacklisted_skills = skills_config.get("blacklisted_skills", [])
     if skill in blacklisted_skills:
@@ -71,7 +71,7 @@ def whitelist_skill(skill, config=None):
 
 
 def make_priority_skill(skill, config=None):
-    config = config or read_mycroft_config()
+    config = config or Configuration()
     skills_config = config.get("skills", {})
     priority_skills = skills_config.get("priority_skills", [])
     if skill not in priority_skills:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -3,5 +3,5 @@ pexpect~=4.8
 requests~=2.26
 json_database~=0.7
 kthread~=0.2
-ovos_config~=0.0,>=0.0.3
+ovos_config~=0.0,>=0.0.6a1
 watchdog


### PR DESCRIPTION
Refactoring to go with fix in ovos-config: https://github.com/OpenVoiceOS/ovos-config/pull/30

Changes to `PIDLock` are technically breaking compat with ovos-utils 0.0.29, but behavior will be patched in https://github.com/OpenVoiceOS/ovos-core/pull/291 for backwards-compatible core references