### PR TITLE
Add show input box method for skills

### DIFF
--- a/ovos_utils/gui.py
+++ b/ovos_utils/gui.py
@@ -914,6 +914,32 @@ class GUIInterface:
         self.show_page("SYSTEM_UrlFrame.qml", override_idle,
                        override_animations)
 
+    def show_input_box(self, title=None, placeholder=None,
+                       confirm_text=None, exit_text=None,
+                       override_idle=None, override_animations=None):
+        self["title"] = title
+        self["placeholder"] = placeholder
+        self["skill_id_handler"] = self.skill_id
+        if not confirm_text:
+            self["confirm_text"] = "Confirm"
+        else:
+            self["confirm_text"] = confirm_text
+
+        if not exit_text:
+            self["exit_text"] = "Exit"
+        else:
+            self["exit_text"] = exit_text
+
+        self.show_page("SYSTEM_InputBox.qml", override_idle,
+                       override_animations)
+
+    def remove_input_box(self):
+        LOG.info(f"GUI pages length {len(self.pages)}")
+        if len(self.pages) > 1:
+            self.remove_page("SYSTEM_InputBox.qml")
+        else:
+            self.release()
+
     def release(self):
         """Signal that this skill is no longer using the GUI,
         allow different platforms to properly handle this event.


### PR DESCRIPTION
Skills required to show input box for any operation can now use the following workflow:

```
def initialize(self)
....
    self.gui.register_handler('input.box.response', self.handle_input_box_response)
    self.gui.register_handler('input.box.close',  self.handle_input_box_close)

def show_input_box(self):
       self.gui.show_input_box(title="A title for the box", placeholder="hint text that will appear in the input field")

def handle_input_box_response(self, message):
        input_text = message.data.get("text")
        self.log.info(input_text)
        self.gui.remove_input_box()

def handle_input_box_close(self, message):
        self.gui.remove_input_box()

```