### PR TITLE
[log] Only creates directory if not stdout

### DIFF
--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -62,7 +62,6 @@ class LOG:
         cls.backup_count = config.get("backup_count", 3)
         cls.level = config.get("level", "INFO")
         cls.diagnostic_mode = config.get("diagnostic", False)
-        os.makedirs(cls.base_path, exist_ok=True)
 
     @classmethod
     def create_logger(cls, name, tostdout=True):
@@ -77,6 +76,7 @@ class LOG:
             logger.addHandler(stdout_handler)
         # log to file
         if cls.base_path != "stdout":
+            os.makedirs(cls.base_path, exist_ok=True)
             path = join(cls.base_path,
                         cls.name.lower().strip() + ".log")
             handler = RotatingFileHandler(path, maxBytes=cls.max_bytes,


### PR DESCRIPTION
This should fix this error when `stdout` is configured:

```
Traceback (most recent call last):
  File "/home/ovos/.venv/bin/ovos_PHAL", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_PHAL/__main__.py", line 12, in main
    phal = PHAL(on_error=error_hook, on_ready=ready_hook, on_stopping=stopping_hook)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_PHAL/service.py", line 42, in __init__
    super().__init__(skill_id=f"ovos.{name}")
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_workshop/app.py", line 14, in __init__
    super().__init__(bus=bus, gui=gui, resources_dir=resources_dir,
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_workshop/skills/ovos.py", line 29, in __init__
    super(OVOSSkill, self).__init__(*args, **kwargs)
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_workshop/skills/mycroft_skill.py", line 83, in __init__
    if is_classic_core():
       ^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_workshop/skills/mycroft_skill.py", line 30, in is_classic_core
    from mycroft.version import OVOS_VERSION_STR
  File "/home/ovos/.venv/lib/python3.11/site-packages/mycroft/__init__.py", line 36, in <module>
    LOG.init(_logs_conf)  # read log level from config
    ^^^^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_utils/log.py", line 60, in init
    os.makedirs(cls.base_path, exist_ok=True)
  File "<frozen os>", line 225, in makedirs
PermissionError: [Errno 13] Permission denied: 'stdout'
```