### PR TITLE
Update `wait_for_exit_signal` to use Event.wait instead of looped sleep

### DIFF
--- a/ovos_utils/__init__.py
+++ b/ovos_utils/__init__.py
@@ -14,7 +14,7 @@ import datetime
 import re
 from functools import lru_cache, wraps
 from os.path import isdir, join
-from threading import Thread
+from threading import Thread, Event
 from time import monotonic_ns
 from time import sleep
 
@@ -141,8 +141,7 @@ def create_loop(target, interval, args=(), kwargs=None):
 def wait_for_exit_signal():
     """Blocks until KeyboardInterrupt is received"""
     try:
-        while True:
-            sleep(100)
+        Event().wait()
     except KeyboardInterrupt:
         pass
 

--- a/test/unittests/scripts/wait_for_exit.py
+++ b/test/unittests/scripts/wait_for_exit.py
@@ -1,0 +1,2 @@
+from ovos_utils import wait_for_exit_signal
+wait_for_exit_signal()

--- a/test/unittests/test_utils.py
+++ b/test/unittests/test_utils.py
@@ -1,4 +1,8 @@
+import signal
 import unittest
+from os.path import join, dirname
+from sys import executable
+from subprocess import Popen, TimeoutExpired
 
 
 class TestHelpers(unittest.TestCase):
@@ -24,11 +28,22 @@ class TestHelpers(unittest.TestCase):
         pass
 
     def test_wait_for_exit_signal(self):
-        # TODO
-        pass
+        test_file = join(dirname(__file__), "scripts", "wait_for_exit.py")
+        wait_thread = Popen([executable, test_file])
+
+        # No return
+        with self.assertRaises(TimeoutExpired):
+            wait_thread.communicate(timeout=1)
+        with self.assertRaises(TimeoutExpired):
+            wait_thread.communicate(timeout=1)
+
+        # Send interrupt and get returncode 0
+        wait_thread.send_signal(signal.SIGINT)
+        self.assertEqual(wait_thread.wait(1), 0)
 
     def test_get_handler_name(self):
         from ovos_utils import get_handler_name
+
         def some_function():
             return
 


### PR DESCRIPTION
Update `wait_for_exit_signal` to use an event instead of looped sleep to reduce CPU usage and add unit tests