### PR TITLE
fix/new_bug

### DIFF
--- a/ovos_utils/messagebus.py
+++ b/ovos_utils/messagebus.py
@@ -160,7 +160,7 @@ class FakeMessage(metaclass=_MutableMessage):
             from mycroft_bus_client import Message as _M
             return _M(*args, **kwargs)
         except:  # FakeMessage
-            return super().__new__(cls, *args, **kwargs)
+            return super().__new__(cls)
 
     def __init__(self, msg_type, data=None, context=None):
         """Used to construct a message object


### PR DESCRIPTION
```
Uncaught exception GET /core (127.0.0.1)
HTTPServerRequest(protocol='http', host='0.0.0.0:8181', method='GET', uri='/core', version='HTTP/1.1', remote_ip='127.0.0.1')
Traceback (most recent call last):
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_utils/messagebus.py", line 160, in __new__
    from mycroft_bus_client import Message as _M
ModuleNotFoundError: No module named 'mycroft_bus_client'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ovos/.venv/lib/python3.11/site-packages/tornado/websocket.py", line 937, in _accept_connection
    open_result = handler.open(*handler.open_args, **handler.open_kwargs)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_messagebus/event_handler.py", line 55, in open
    self.write_message(Message("connected").serialize())
                       ^^^^^^^^^^^^^^^^^^^^
  File "/home/ovos/.venv/lib/python3.11/site-packages/ovos_utils/messagebus.py", line 163, in __new__
    return super().__new__(cls, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: object.__new__() takes exactly one argument (the type to instantiate)
```

closes https://github.com/OpenVoiceOS/ovos-utils/issues/137

explanation https://stackoverflow.com/questions/59217884/new-method-giving-error-object-new-takes-exactly-one-argument-the-typ