### PR TITLE
Configurable skills base directory

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install package
         run: |
           pip install .[all]
-      - uses: pypa/gh-action-pip-audit@v1.0.0
+      - uses: pypa/gh-action-pip-audit@v1.0.7
         with:
           # Ignore setuptools vulnerability we can't do much about
           ignore-vulns: |

--- a/ovos_utils/skills/locations.py
+++ b/ovos_utils/skills/locations.py
@@ -55,13 +55,13 @@ def get_skill_directories(conf: Optional[dict] = None) -> List[str]:
     # we are still dependent on the mycroft-core structure of skill_id/__init__.py
 
     conf = conf or read_mycroft_config()
-
+    folder = conf["skills"].get("directory") or "skills"
     # load all valid XDG paths
     # NOTE: skills are actually code, but treated as user data!
     # they should be considered applets rather than full applications
     skill_locations = list(reversed(
-        [join(p, "skills") for p in get_xdg_data_dirs() if
-         isdir(join(p, "skills"))]
+        [join(p, folder) for p in get_xdg_data_dirs() if
+         isdir(join(p, folder))]
     ))
 
     # load the default skills folder
@@ -103,6 +103,7 @@ def get_default_skills_directory(conf: Optional[dict] = None) -> str:
     """
     conf = conf or read_mycroft_config()
     path_override = conf["skills"].get("directory_override")
+    folder = conf["skills"].get("directory") or "skills"
 
     # if .conf wants to use a specific path, use it!
     if path_override:
@@ -114,12 +115,12 @@ def get_default_skills_directory(conf: Optional[dict] = None) -> str:
             len(conf["skills"].get("extra_directories")) > 0:
         skills_folder = expanduser(conf["skills"]["extra_directories"][0])
     else:
-        skills_folder = join(get_xdg_data_save_path(), "skills")
+        skills_folder = join(get_xdg_data_save_path(), folder)
     # create folder if needed
     try:
         makedirs(skills_folder, exist_ok=True)
     except PermissionError:  # old style /opt/mycroft/skills not available
-        skills_folder = join(get_xdg_data_save_path(), "skills")
+        skills_folder = join(get_xdg_data_save_path(), folder)
         makedirs(skills_folder, exist_ok=True)
 
     return skills_folder

--- a/test/unittests/test_skills.py
+++ b/test/unittests/test_skills.py
@@ -1,6 +1,6 @@
 import unittest
 from os import environ
-from os.path import isdir, join, dirname
+from os.path import isdir, join, dirname, basename
 from unittest.mock import patch
 from ovos_utils.skills.locations import get_skill_directories
 from ovos_utils.skills.locations import get_default_skills_directory
@@ -94,11 +94,29 @@ class TestLocations(unittest.TestCase):
         self.assertEqual(get_skill_directories(config),
                          [default_dir, extra_dir])
 
-
         # Define invalid directories in extra_directories
         config['skills']['extra_directories'] += ["/not/a/directory"]
         self.assertEqual(get_skill_directories(config),
                          [default_dir, extra_dir])
+
+        # Default directory
+        mock_config = {'skills': {}}
+        default_directories = get_skill_directories(mock_config)
+        for directory in default_directories:
+            self.assertEqual(basename(directory), 'skills')
+        # Configured directory
+        mock_config['skills']['directory'] = 'test'
+        test_directories = get_skill_directories(mock_config)
+        for directory in test_directories:
+            self.assertEqual(basename(directory), 'test')
+        self.assertEqual(len(default_directories), len(test_directories))
+        # Extra directory
+        extra_dir = join(dirname(__file__), 'skills')
+        mock_config['skills']['extra_directories'] = [extra_dir]
+        extra_directories = get_skill_directories(mock_config)
+        self.assertEqual(extra_directories[-1], extra_dir)
+        for directory in test_directories:
+            self.assertIn(directory, extra_directories)
 
     def test_get_default_skills_directory(self):
         if not ovos_config:
@@ -123,6 +141,21 @@ class TestLocations(unittest.TestCase):
         # XDG (empty extra_directories)
         config = {"skills": {"extra_directories": []}}
         self.assertEqual(get_default_skills_directory(config), xdg_skills_dir)
+
+        # Default directory
+        mock_config = {'skills': {}}
+        default_dir = get_default_skills_directory(mock_config)
+        self.assertTrue(isdir(default_dir))
+        self.assertEqual(basename(default_dir), 'skills')
+        self.assertEqual(dirname(dirname(default_dir)),
+                         join(dirname(__file__), "test_skills_xdg"))
+        # Override directory
+        mock_config['skills']['directory'] = 'test'
+        test_dir = get_default_skills_directory(mock_config)
+        self.assertTrue(isdir(test_dir))
+        self.assertEqual(basename(test_dir), 'test')
+        self.assertEqual(dirname(dirname(test_dir)),
+                         join(dirname(__file__), "test_skills_xdg"))
 
     def test_get_plugin_skills(self):
         dirs, ids = get_plugin_skills()


### PR DESCRIPTION
(re-)implement handling of `Configuration['skills']['directory']` for compat. with ovos-workshop
Related to https://github.com/OpenVoiceOS/OVOS-workshop/pull/89