### PR TITLE
loosen pexpect requirement

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-pexpect~=4.8
+pexpect>=4.6
 requests~=2.26
 json_database~=0.7
 kthread~=0.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
-pexpect>=4.6
+pexpect~=4.6
 requests~=2.26
 json_database~=0.7
 kthread~=0.2


### PR DESCRIPTION
Allows the ability to use ovos-utils with a Home Assistant integration