### PR TITLE
Add deprecation log helpers

### DIFF
--- a/ovos_utils/__init__.py
+++ b/ovos_utils/__init__.py
@@ -32,8 +32,9 @@ class classproperty(property):
     def __get__(self, owner_self, owner_cls):
         return self.fget(owner_cls)
 
-@deprecated("This method is deprecated. Anything depending on `mycroft`"
-            "should install `ovos-core` as a dependency")
+
+@deprecated("Anything depending on `mycroft`"
+            "should install `ovos-core` as a dependency", "0.1.0")
 def ensure_mycroft_import():
     # TODO: Deprecate in 0.1.0
     try:
@@ -47,8 +48,9 @@ def ensure_mycroft_import():
         else:
             raise
 
-@deprecated("This method is deprecated. Code should import from the current"
-                "namespace; other system paths are irrelevant.")
+
+@deprecated("Code should import from the current"
+            "namespace; other system paths are irrelevant.", "0.1.0")
 def get_mycroft_root():
     # TODO: Deprecate in 0.1.0
     paths = [

--- a/ovos_utils/__init__.py
+++ b/ovos_utils/__init__.py
@@ -23,7 +23,7 @@ import kthread
 # TODO: Deprecate below imports
 from ovos_utils.file_utils import resolve_ovos_resource_file, resolve_resource_file
 from ovos_utils.network_utils import get_ip, get_external_ip, is_connected_dns, is_connected_http, is_connected
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 
 
 class classproperty(property):
@@ -32,11 +32,10 @@ class classproperty(property):
     def __get__(self, owner_self, owner_cls):
         return self.fget(owner_cls)
 
-
+@deprecated("This method is deprecated. Anything depending on `mycroft`"
+            "should install `ovos-core` as a dependency")
 def ensure_mycroft_import():
     # TODO: Deprecate in 0.1.0
-    LOG.warning("This method is deprecated. Anything depending on `mycroft`"
-                "should install `ovos-core` as a dependency")
     try:
         import mycroft
     except ImportError:
@@ -48,11 +47,10 @@ def ensure_mycroft_import():
         else:
             raise
 
-
+@deprecated("This method is deprecated. Code should import from the current"
+                "namespace; other system paths are irrelevant.")
 def get_mycroft_root():
     # TODO: Deprecate in 0.1.0
-    LOG.warning("This method is deprecated. Code should import from the current"
-                "namespace; other system paths are irrelevant.")
     paths = [
         "/opt/venvs/mycroft-core/lib/python3.7/site-packages/",  # mark1/2
         "/opt/venvs/mycroft-core/lib/python3.4/site-packages/ ",  # old mark1 installs

--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -3,7 +3,7 @@ from os import makedirs
 from os.path import join, expanduser, exists, isfile
 
 import ovos_utils.xdg_utils as xdg
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 
 
 # TODO - deprecate this submodule in 0.1.0
@@ -137,9 +137,9 @@ def get_xdg_data_save_path():
         return expanduser("~/.local/share/mycroft")
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_xdg_config_save_path():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locations import get_xdg_config_save_path as _get
         return _get()

--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -10,8 +10,7 @@ from ovos_utils.log import LOG, deprecated
 # note that a couple of these are also used inside ovos-utils
 # perhaps those usages should also move into workshop ?
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_default_lang():
     try:
         from ovos_config.locale import get_default_lang as _get
@@ -20,8 +19,7 @@ def get_default_lang():
         return read_mycroft_config().get("lang", "en-us")
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def find_user_config():
     try:
         from ovos_config.locations import find_user_config as _get
@@ -31,14 +29,12 @@ def find_user_config():
         return join(get_xdg_config_save_path(), get_config_filename())
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_webcache_location():
     return join(get_xdg_config_save_path(), 'web_cache.json')
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_config_locations(default=True, web_cache=True, system=True,
                          old_user=True, user=True):
     try:
@@ -60,8 +56,7 @@ def get_config_locations(default=True, web_cache=True, system=True,
         return locs
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_ovos_config():
     try:
         from ovos_config.meta import get_ovos_config as _get
@@ -72,8 +67,7 @@ def get_ovos_config():
                 "config_filename": "mycroft.conf"}
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_xdg_base():
     try:
         from ovos_config.meta import get_xdg_base as _get
@@ -82,8 +76,7 @@ def get_xdg_base():
         return "mycroft"
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_xdg_config_locations():
     # This includes both the user config and
     # /etc/xdg/mycroft/mycroft.conf
@@ -94,8 +87,7 @@ def get_xdg_config_locations():
     return xdg_paths
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_xdg_data_dirs():
     try:
         from ovos_config.locations import get_xdg_data_dirs as _get
@@ -104,8 +96,7 @@ def get_xdg_data_dirs():
         return [expanduser("~/.local/share/mycroft")]
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_xdg_config_dirs(folder=None):
     try:
         from ovos_config.locations import get_xdg_config_dirs as _get
@@ -116,8 +107,7 @@ def get_xdg_config_dirs(folder=None):
         return [join(path, folder) for path in xdg_dirs]
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_xdg_cache_save_path(folder=None):
     try:
         from ovos_config.locations import get_xdg_cache_save_path as _get
@@ -127,8 +117,7 @@ def get_xdg_cache_save_path(folder=None):
         return join(xdg.xdg_cache_home(), folder)
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_xdg_data_save_path():
     try:
         from ovos_config.locations import get_xdg_data_save_path as _get
@@ -137,8 +126,7 @@ def get_xdg_data_save_path():
         return expanduser("~/.local/share/mycroft")
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_xdg_config_save_path():
     try:
         from ovos_config.locations import get_xdg_config_save_path as _get
@@ -147,15 +135,13 @@ def get_xdg_config_save_path():
         return expanduser("~/.config/mycroft")
 
 
-@deprecated("XDG is always used.This function will be removed in "
-            "ovos_utils 0.1.0")
+@deprecated("XDG is always used.", "0.1.0")
 def is_using_xdg():
     """ DEPRECATED """
     return True
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def set_xdg_base(*args, **kwargs):
     try:
         from ovos_config.meta import set_xdg_base as _set
@@ -164,8 +150,7 @@ def set_xdg_base(*args, **kwargs):
         pass
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def set_config_filename(*args, **kwargs):
     try:
         from ovos_config.meta import config_filename as _set
@@ -174,8 +159,7 @@ def set_config_filename(*args, **kwargs):
         pass
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_config_filename():
     try:
         from ovos_config.locale import get_config_filename as _get
@@ -184,8 +168,7 @@ def get_config_filename():
         return "mycroft.conf"
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def get_ovos_default_config_paths():
     try:
         from ovos_config.meta import get_ovos_default_config_paths as _get
@@ -194,8 +177,7 @@ def get_ovos_default_config_paths():
         return ["/etc/OpenVoiceOS/ovos.conf"]
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def read_mycroft_config():
     try:
         from ovos_config import Configuration
@@ -212,8 +194,7 @@ def read_mycroft_config():
     }
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def update_mycroft_config(config, path=None, bus=None):
     try:
         from ovos_config.config import update_mycroft_config as _update
@@ -227,8 +208,7 @@ def update_mycroft_config(config, path=None, bus=None):
         json.dump(config, f, indent=2)
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def set_default_config(*args, **kwargs):
     try:
         from ovos_config.meta import set_default_config as _set
@@ -237,8 +217,7 @@ def set_default_config(*args, **kwargs):
         pass
 
 
-@deprecated("configuration moved to the `ovos_config` package. This submodule "
-            "will be removed in ovos_utils 0.1.0")
+@deprecated("configuration moved to the `ovos_config` package.", "0.1.0")
 def save_ovos_core_config(*args, **kwargs):
     try:
         from ovos_config.meta import save_ovos_config as _set

--- a/ovos_utils/configuration.py
+++ b/ovos_utils/configuration.py
@@ -10,9 +10,9 @@ from ovos_utils.log import LOG, deprecated
 # note that a couple of these are also used inside ovos-utils
 # perhaps those usages should also move into workshop ?
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_default_lang():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locale import get_default_lang as _get
         return _get()
@@ -20,9 +20,9 @@ def get_default_lang():
         return read_mycroft_config().get("lang", "en-us")
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def find_user_config():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locations import find_user_config as _get
         return _get()
@@ -31,16 +31,16 @@ def find_user_config():
         return join(get_xdg_config_save_path(), get_config_filename())
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_webcache_location():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return join(get_xdg_config_save_path(), 'web_cache.json')
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_config_locations(default=True, web_cache=True, system=True,
                          old_user=True, user=True):
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locations import get_config_locations as _get
         return _get(default, web_cache, system, old_user, user)
@@ -60,9 +60,9 @@ def get_config_locations(default=True, web_cache=True, system=True,
         return locs
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_ovos_config():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.meta import get_ovos_config as _get
         return _get()
@@ -72,9 +72,9 @@ def get_ovos_config():
                 "config_filename": "mycroft.conf"}
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_xdg_base():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.meta import get_xdg_base as _get
         return _get()
@@ -82,9 +82,9 @@ def get_xdg_base():
         return "mycroft"
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_xdg_config_locations():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     # This includes both the user config and
     # /etc/xdg/mycroft/mycroft.conf
     xdg_paths = list(reversed(
@@ -94,9 +94,9 @@ def get_xdg_config_locations():
     return xdg_paths
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_xdg_data_dirs():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locations import get_xdg_data_dirs as _get
         return _get()
@@ -104,9 +104,9 @@ def get_xdg_data_dirs():
         return [expanduser("~/.local/share/mycroft")]
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_xdg_config_dirs(folder=None):
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locations import get_xdg_config_dirs as _get
         return _get()
@@ -116,9 +116,9 @@ def get_xdg_config_dirs(folder=None):
         return [join(path, folder) for path in xdg_dirs]
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_xdg_cache_save_path(folder=None):
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locations import get_xdg_cache_save_path as _get
         return _get()
@@ -127,9 +127,9 @@ def get_xdg_cache_save_path(folder=None):
         return join(xdg.xdg_cache_home(), folder)
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_xdg_data_save_path():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locations import get_xdg_data_save_path as _get
         return _get()
@@ -147,16 +147,16 @@ def get_xdg_config_save_path():
         return expanduser("~/.config/mycroft")
 
 
+@deprecated("XDG is always used.This function will be removed in "
+            "ovos_utils 0.1.0")
 def is_using_xdg():
     """ DEPRECATED """
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return True
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def set_xdg_base(*args, **kwargs):
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.meta import set_xdg_base as _set
         _set(*args, **kwargs)
@@ -164,9 +164,9 @@ def set_xdg_base(*args, **kwargs):
         pass
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def set_config_filename(*args, **kwargs):
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.meta import config_filename as _set
         _set(*args, **kwargs)
@@ -174,9 +174,9 @@ def set_config_filename(*args, **kwargs):
         pass
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_config_filename():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.locale import get_config_filename as _get
         return _get()
@@ -184,9 +184,9 @@ def get_config_filename():
         return "mycroft.conf"
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def get_ovos_default_config_paths():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.meta import get_ovos_default_config_paths as _get
         return _get()
@@ -194,9 +194,9 @@ def get_ovos_default_config_paths():
         return ["/etc/OpenVoiceOS/ovos.conf"]
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def read_mycroft_config():
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config import Configuration
         return Configuration()
@@ -212,9 +212,9 @@ def read_mycroft_config():
     }
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def update_mycroft_config(config, path=None, bus=None):
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.config import update_mycroft_config as _update
         _update(config, path, bus)
@@ -227,9 +227,9 @@ def update_mycroft_config(config, path=None, bus=None):
         json.dump(config, f, indent=2)
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def set_default_config(*args, **kwargs):
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.meta import set_default_config as _set
         _set(*args, **kwargs)
@@ -237,9 +237,9 @@ def set_default_config(*args, **kwargs):
         pass
 
 
+@deprecated("configuration moved to the `ovos_config` package. This submodule "
+            "will be removed in ovos_utils 0.1.0")
 def save_ovos_core_config(*args, **kwargs):
-    LOG.warning("configuration moved to the `ovos_config` package. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         from ovos_config.meta import save_ovos_config as _set
         _set(*args, **kwargs)

--- a/ovos_utils/dialog.py
+++ b/ovos_utils/dialog.py
@@ -150,9 +150,7 @@ def get_dialog(phrase: str, lang: str = None,
     """
 
     if not lang:
-        log_deprecation("Expected a string lang and got None. This config"
-                        "fallback behavior will be deprecated in a future "
-                        "release")
+        log_deprecation("Expected a string lang and got None.", "0.1.0")
         try:
             from ovos_config.config import read_mycroft_config
             conf = read_mycroft_config()

--- a/ovos_utils/dialog.py
+++ b/ovos_utils/dialog.py
@@ -8,7 +8,7 @@ from typing import Optional
 from ovos_utils.bracket_expansion import expand_options
 from ovos_utils.file_utils import resolve_resource_file
 from ovos_utils.lang import translate_word
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 
 
 class MustacheDialogRenderer:
@@ -150,8 +150,9 @@ def get_dialog(phrase: str, lang: str = None,
     """
 
     if not lang:
-        LOG.warning(f"Expected a string lang and got None. This config"
-                    f"fallback behavior will be deprecated in a future release")
+        log_deprecation("Expected a string lang and got None. This config"
+                        "fallback behavior will be deprecated in a future "
+                        "release")
         try:
             from ovos_config.config import read_mycroft_config
             conf = read_mycroft_config()

--- a/ovos_utils/enclosure/__init__.py
+++ b/ovos_utils/enclosure/__init__.py
@@ -21,7 +21,7 @@ class MycroftEnclosures(str, Enum):
 
 
 @deprecated("This method is deprecated. Code should import from the current"
-            "namespace; other system paths are irrelevant.")
+            "namespace; other system paths are irrelevant.", "0.1.0")
 def enclosure2rootdir(enclosure: MycroftEnclosures = None) -> Optional[str]:
     """
     Find the default installed core location for a specific platform.
@@ -46,7 +46,7 @@ def enclosure2rootdir(enclosure: MycroftEnclosures = None) -> Optional[str]:
 
 
 @deprecated("This method is deprecated. Platform-specific code should"
-            "use ovos_utils.fingerprinting.detect_platform directly")
+            "use ovos_utils.fingerprinting.detect_platform directly", "0.1.0")
 def detect_enclosure() -> MycroftEnclosures:
     """
     Determine which enclosure is present on this file system.

--- a/ovos_utils/enclosure/__init__.py
+++ b/ovos_utils/enclosure/__init__.py
@@ -3,7 +3,7 @@ from ovos_utils.fingerprinting import detect_platform, MycroftPlatform
 from enum import Enum
 from os.path import exists
 from typing import Optional
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 
 
 class MycroftEnclosures(str, Enum):
@@ -20,6 +20,8 @@ class MycroftEnclosures(str, Enum):
     OTHER = "unknown"
 
 
+@deprecated("This method is deprecated. Code should import from the current"
+            "namespace; other system paths are irrelevant.")
 def enclosure2rootdir(enclosure: MycroftEnclosures = None) -> Optional[str]:
     """
     Find the default installed core location for a specific platform.
@@ -27,8 +29,6 @@ def enclosure2rootdir(enclosure: MycroftEnclosures = None) -> Optional[str]:
     @return: string default root path
     """
     # TODO: Deprecate in 0.1.0
-    LOG.warning("This method is deprecated. Code should import from the current"
-                "namespace; other system paths are irrelevant.")
     enclosure = enclosure or detect_enclosure()
     if enclosure == MycroftEnclosures.OLD_MARK1:
         return MycroftRootLocations.OLD_MARK1
@@ -45,14 +45,14 @@ def enclosure2rootdir(enclosure: MycroftEnclosures = None) -> Optional[str]:
     return None
 
 
+@deprecated("This method is deprecated. Platform-specific code should"
+            "use ovos_utils.fingerprinting.detect_platform directly")
 def detect_enclosure() -> MycroftEnclosures:
     """
     Determine which enclosure is present on this file system.
     @return: MycroftEnclosures object detected
     """
     # TODO: Deprecate in 0.1.0
-    LOG.warning("This method is deprecated. Platform-specific code should"
-                "use ovos_utils.fingerprinting.detect_platform directly")
     platform = detect_platform()
     if platform == MycroftPlatform.MARK1:
         if exists(MycroftRootLocations.OLD_MARK1):

--- a/ovos_utils/events.py
+++ b/ovos_utils/events.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from inspect import signature
 from typing import Callable, Optional
 from ovos_utils.intents.intent_service_interface import to_alnum
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation, deprecated
 from ovos_utils.messagebus import FakeBus, FakeMessage as Message
 
 
@@ -205,9 +205,11 @@ class EventSchedulerInterface:
         # NOTE: can not rename or move sched_id/name arguments to keep api
         # compatibility
         if name:
-            LOG.warning("name argument has been deprecated! use skill_id instead")
+            log_deprecation("name argument has been deprecated! "
+                            "use skill_id instead", "0.1.0")
         if sched_id:
-            LOG.warning("sched_id argument has been deprecated! use skill_id instead")
+            log_deprecation("sched_id argument has been deprecated! "
+                            "use skill_id instead", "0.1.0")
 
         self.skill_id = skill_id or sched_id or name or self.__class__.__name__
         self.bus = bus
@@ -408,33 +410,37 @@ class EventSchedulerInterface:
         self.events.clear()
 
     @property
+    @deprecated("self.sched_id has been deprecated! use self.skill_id instead",
+                "0.1.0")
     def sched_id(self):
         """DEPRECATED: do not use, method only for api backwards compatibility
         Logs a warning and returns self.skill_id
         """
-        LOG.warning("self.sched_id has been deprecated! use self.skill_id instead")
         return self.skill_id
 
     @sched_id.setter
+    @deprecated("self.sched_id has been deprecated! use self.skill_id instead",
+                "0.1.0")
     def sched_id(self, skill_id):
         """DEPRECATED: do not use, method only for api backwards compatibility
         Logs a warning and sets self.skill_id
         """
-        LOG.warning("self.sched_id has been deprecated! use self.skill_id instead")
         self.skill_id = skill_id
 
     @property
+    @deprecated("self.name has been deprecated! use self.skill_id instead",
+                "0.1.0")
     def name(self):
         """DEPRECATED: do not use, method only for api backwards compatibility
         Logs a warning and returns self.skill_id
         """
-        LOG.warning("self.name has been deprecated! use self.skill_id instead")
         return self.skill_id
 
     @name.setter
+    @deprecated("self.sched_id has been deprecated! use self.skill_id instead",
+                "0.1.0")
     def name(self, skill_id):
         """DEPRECATED: do not use, method only for api backwards compatibility
         Logs a warning and sets self.skill_id
         """
-        LOG.warning("self.name has been deprecated! use self.skill_id instead")
         self.skill_id = skill_id

--- a/ovos_utils/file_utils.py
+++ b/ovos_utils/file_utils.py
@@ -6,7 +6,6 @@ import tempfile
 from threading import RLock
 from typing import Optional, List
 
-import time
 from os import walk
 from os.path import dirname
 from os.path import splitext, join
@@ -15,7 +14,7 @@ from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
 from ovos_utils.bracket_expansion import expand_options
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_utils.system import search_mycroft_core_location
 
 
@@ -150,8 +149,7 @@ def resolve_resource_file(res_name: str, root_path: Optional[str] = None,
         str: path to resource or None if no resource found
     """
     if config is None:
-        LOG.warning(f"Expected a dict config and got None. This config"
-                    f"fallback behavior will be deprecated in a future release")
+        log_deprecation(f"Expected a dict config and got None.", "0.1.0")
         try:
             from ovos_config.config import read_mycroft_config
             config = read_mycroft_config()

--- a/ovos_utils/fingerprinting.py
+++ b/ovos_utils/fingerprinting.py
@@ -2,7 +2,7 @@ import platform
 import socket
 from enum import Enum
 from os.path import join, isfile
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 from ovos_utils.system import is_installed, is_running_from_module, has_screen, \
     get_desktop_environment, search_mycroft_core_location, is_process_running
 
@@ -21,16 +21,14 @@ class MycroftPlatform(str, Enum):
     OTHER = "unknown"
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def detect_platform():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return max(((k, v) for k, v in classify_fingerprint().items()),
                key=lambda k: k[1])[0]
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def get_config_fingerprint(config=None):
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     if not config:
         try:
             from ovos_config.config import read_mycroft_config
@@ -54,9 +52,8 @@ def get_config_fingerprint(config=None):
     }
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def get_platform_fingerprint():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return {
         "hostname": socket.gethostname(),
         "platform": platform.platform(),
@@ -83,23 +80,20 @@ def get_platform_fingerprint():
     }
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def get_fingerprint():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     finger = get_platform_fingerprint()
     finger["configuration"] = get_config_fingerprint()
     return finger
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def core_supports_xdg():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return True  # no longer optional
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def get_mycroft_version():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:  # ovos
         from mycroft.version import OVOS_VERSION_STR
         return OVOS_VERSION_STR
@@ -139,9 +133,8 @@ def get_mycroft_version():
         return None
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def is_chatterbox_core():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         import chatterbox
         return True
@@ -149,9 +142,8 @@ def is_chatterbox_core():
         return False
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def is_neon_core():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         import neon_core
         return True
@@ -159,9 +151,8 @@ def is_neon_core():
         return False
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def is_mycroft_core():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     try:
         import mycroft
         return True
@@ -169,33 +160,28 @@ def is_mycroft_core():
         return False
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def is_vanilla_mycroft_core():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return is_mycroft_core() and not is_ovos()
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def is_holmes():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return "HolmesV" in (get_mycroft_version() or "") or is_mycroft_lib()
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def is_mycroft_lib():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return "mycroft-lib" in (get_mycroft_version() or "")
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def is_ovos():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     return is_running_from_module("ovos-core")
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def classify_platform_print(fingerprint=None):
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     fingerprint = fingerprint or get_platform_fingerprint()
     # key, val pairs that indicate a certain platform
     fingerprints = {
@@ -354,9 +340,8 @@ def classify_platform_print(fingerprint=None):
     return {k: v / m for k, v in key_counts.items()}
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def classify_config_print(fingerprint=None):
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     fingerprint = fingerprint or get_config_fingerprint()
 
     # key, val pairs that indicate a certain platform
@@ -476,9 +461,8 @@ def classify_config_print(fingerprint=None):
     return {k: v / m for k, v in key_counts.items()}
 
 
+@deprecated("fingerprinting utils are deprecated.", "0.1.0")
 def classify_fingerprint():
-    LOG.warning("fingerprinting utils are deprecated. This submodule "
-                "will be removed in ovos_utils 0.1.0")
     plat = classify_platform_print()
     conf = classify_config_print()
     for k, v in conf.items():

--- a/ovos_utils/gui.py
+++ b/ovos_utils/gui.py
@@ -6,7 +6,7 @@ from enum import IntEnum
 from os.path import join
 
 from ovos_utils import resolve_ovos_resource_file, resolve_resource_file
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_utils.messagebus import wait_for_reply, get_mycroft_bus, Message
 from ovos_utils.system import is_installed, has_screen, is_process_running
 
@@ -502,9 +502,7 @@ class GUIInterface:
     def __init__(self, skill_id, bus=None, remote_server=None, config=None,
                  resource_dir=None):
         if not config:
-            LOG.warning(f"Expected a dict config and got None. This config"
-                        f"fallback behavior will be deprecated in a future "
-                        f"release")
+            log_deprecation(f"Expected a dict config and got None.", "0.1.0")
             try:
                 from ovos_config.config import read_mycroft_config
                 config = read_mycroft_config().get("gui", {})

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -173,8 +173,8 @@ def init_service_logger(service_name):
 
 
 def log_deprecation(log_message: str = "DEPRECATED",
-                    func_name: str = None,
-                    deprecation_version: str = "Unknown"):
+                    deprecation_version: str = "Unknown",
+                    func_name: str = None):
     """
     Log a deprecation warning with information for the call outside the module
     that is generating the warning
@@ -213,7 +213,9 @@ def deprecated(log_message: str, deprecation_version: str):
     @param deprecation_version: package version in which deprecation will occur
     """
     def wrapped(func):
-        log_deprecation(log_message, func.__name__, deprecation_version)
+        log_deprecation(log_message=log_message,
+                        func_name=func.__name__,
+                        deprecation_version=deprecation_version)
         return func
 
     return wrapped

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -182,6 +182,7 @@ def log_deprecation(log_message: str = "DEPRECATED"):
     stack = inspect.stack()[1:]  # [0] is this method
     call_info = "Unknown Origin"
     origin_module = None
+    log_name = LOG.name
     for call in stack:
         module = inspect.getmodule(call.frame)
         name = module.__name__ if module else call.filename
@@ -191,11 +192,12 @@ def log_deprecation(log_message: str = "DEPRECATED"):
             continue
         if not origin_module:
             origin_module = name
+            log_name = name + ':' + call[3] + ':' + str(call[2])
             continue
         if not name.startswith(origin_module):
             call_info = f"{name}:{call.lineno}"
             break
-    LOG.warning(f"{log_message} - {call_info}")
+    LOG.create_logger(log_name).warning(f"{log_message} - {call_info}")
 
 
 def deprecated(log_message: str, *args, **kwargs):

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -172,12 +172,15 @@ def init_service_logger(service_name):
     LOG.init(_logs_conf)  # read log level from config
 
 
-def log_deprecation(log_message: str = "DEPRECATED", func_name: str = None):
+def log_deprecation(log_message: str = "DEPRECATED",
+                    func_name: str = None,
+                    deprecation_version: str = "Unknown"):
     """
     Log a deprecation warning with information for the call outside the module
     that is generating the warning
     @param log_message: Log contents describing the deprecation
     @param func_name: decorated function name (else read from stack)
+    @param deprecation_version: package version in which method will be deprecated
     """
     import inspect
     stack = inspect.stack()[1:]  # [0] is this method
@@ -199,16 +202,18 @@ def log_deprecation(log_message: str = "DEPRECATED", func_name: str = None):
             call_info = f"{name}:{call.lineno}"
             break
     # Explicitly format log to print origin log reference
-    LOG.create_logger(log_name).warning(f"{log_message} - {call_info}")
+    LOG.create_logger(log_name).warning(
+        f"Deprecation version={deprecation_version}. Caller={call_info}. {log_message}")
 
 
-def deprecated(log_message: str, *args, **kwargs):
+def deprecated(log_message: str, deprecation_version: str):
     """
     Decorator to log deprecation on call to deprecated function
     @param log_message: Deprecation log message
+    @param deprecation_version: package version in which deprecation will occur
     """
     def wrapped(func):
-        log_deprecation(log_message, func.__name__)
+        log_deprecation(log_message, func.__name__, deprecation_version)
         return func
 
     return wrapped

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -197,6 +197,8 @@ def log_deprecation(log_message: str = "DEPRECATED"):
         if not name.startswith(origin_module):
             call_info = f"{name}:{call.lineno}"
             break
+    # Explicitly format log to print origin log reference
+    LOG.debug(f"Logging deprecation to log: {log_name}")
     LOG.create_logger(log_name).warning(f"{log_message} - {call_info}")
 
 

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -192,7 +192,7 @@ def log_deprecation(log_message: str = "DEPRECATED"):
             continue
         if not origin_module:
             origin_module = name
-            log_name = name + ':' + call[3] + ':' + str(call[2])
+            log_name = f"{LOG.name} - {name}:{call[3]}:{call[2]}"
             continue
         if not name.startswith(origin_module):
             call_info = f"{name}:{call.lineno}"

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -172,11 +172,12 @@ def init_service_logger(service_name):
     LOG.init(_logs_conf)  # read log level from config
 
 
-def log_deprecation(log_message: str = "DEPRECATED"):
+def log_deprecation(log_message: str = "DEPRECATED", func_name: str = None):
     """
     Log a deprecation warning with information for the call outside the module
     that is generating the warning
     @param log_message: Log contents describing the deprecation
+    @param func_name: decorated function name (else read from stack)
     """
     import inspect
     stack = inspect.stack()[1:]  # [0] is this method
@@ -192,13 +193,12 @@ def log_deprecation(log_message: str = "DEPRECATED"):
             continue
         if not origin_module:
             origin_module = name
-            log_name = f"{LOG.name} - {name}:{call[3]}:{call[2]}"
+            log_name = f"{LOG.name} - {name}:{func_name or call[3]}:{call[2]}"
             continue
         if not name.startswith(origin_module):
             call_info = f"{name}:{call.lineno}"
             break
     # Explicitly format log to print origin log reference
-    LOG.debug(f"Logging deprecation to log: {log_name}")
     LOG.create_logger(log_name).warning(f"{log_message} - {call_info}")
 
 
@@ -208,7 +208,7 @@ def deprecated(log_message: str, *args, **kwargs):
     @param log_message: Deprecation log message
     """
     def wrapped(func):
-        log_deprecation(log_message)
+        log_deprecation(log_message, func.__name__)
         return func
 
     return wrapped

--- a/ovos_utils/messagebus.py
+++ b/ovos_utils/messagebus.py
@@ -9,7 +9,7 @@ from pyee import BaseEventEmitter
 
 from ovos_utils import create_loop
 from ovos_utils.json_helper import merge_dict
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 from ovos_utils.metrics import Stopwatch
 
 _DEFAULT_WS_CONFIG = {"host": "0.0.0.0",
@@ -306,8 +306,8 @@ class FakeMessage(metaclass=_MutableMessage):
 
 class Message(FakeMessage):
     def __int__(self, *args, **kwargs):
-        LOG.warning(f"This reference is deprecated, import from "
-                    f"`ovos_bus_client.message` directly")
+        log_deprecation(f"Import from ovos_bus_client.message directly",
+                        "0.1.0")
         FakeMessage.__init__(self, *args, **kwargs)
 
 
@@ -756,9 +756,7 @@ class BusFeedProvider:
                 bus (WebsocketClient): mycroft messagebus websocket
         """
         if not config:
-            LOG.warning(f"Expected a dict config and got None. This config"
-                        f"fallback behavior will be deprecated in a future "
-                        f"release")
+            log_deprecation(f"Expected a dict config and got None.", "0.1.0")
             try:
                 from ovos_config.config import read_mycroft_config
                 config = read_mycroft_config()
@@ -909,6 +907,7 @@ class BusFeedConsumer:
         self.name = name or self.__class__.__name__
         self.bus = bus or get_mycroft_bus()
         if not config:
+            log_deprecation(f"Expected a dict config and got None.", "0.1.0")
             try:
                 from ovos_config.config import read_mycroft_config
                 config = read_mycroft_config()

--- a/ovos_utils/ovos_service_api.py
+++ b/ovos_utils/ovos_service_api.py
@@ -7,7 +7,7 @@ from ovos_utils.log import deprecated
 
 
 class OVOSApiService:
-    @deprecated("Import from ovos-backend-client.api", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api.BaseApi", "0.1.0")
     def __init__(self) -> None:
         self.uuid_storage = JsonStorageXDG("ovos_api_uuid")
         self.token_storage = JsonStorageXDG("ovos_api_token")
@@ -44,7 +44,7 @@ class OVOSApiService:
 
 
 class OvosWeather:
-    @deprecated("Import from ovos-backend-client.api", "0.1.0")
+    @deprecated("Import ovos-backend-client.api.OpenWeatherMapApi", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -96,7 +96,7 @@ class OvosWeather:
 
 
 class OvosWolframAlpha:
-    @deprecated("Import from ovos-backend-client.api", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api.WolframAlphaApi", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -136,7 +136,7 @@ class OvosWolframAlpha:
 
 
 class OvosEdamamRecipe:
-    @deprecated("Import from ovos-backend-client.api", "0.1.0")
+    @deprecated("No direct replacement", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -158,7 +158,7 @@ class OvosEdamamRecipe:
 
 
 class OvosOmdb:
-    @deprecated("Import from ovos-backend-client.api", "0.1.0")
+    @deprecated("No direct replacement", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -182,7 +182,7 @@ class OvosOmdb:
 
 
 class OvosGeolocate:
-    @deprecated("Import from ovos-backend-client.api", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api.GeolocationApi", "0.1.0")
     def __init__(self):
         pass
 
@@ -206,7 +206,7 @@ class OvosGeolocate:
 
 
 class OvosSendMail:
-    @deprecated("Import from ovos-backend-client.api", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api.EmailApi", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 

--- a/ovos_utils/ovos_service_api.py
+++ b/ovos_utils/ovos_service_api.py
@@ -1,14 +1,14 @@
 import requests
 from json_database import JsonStorageXDG
-from ovos_utils.log import LOG
+from ovos_utils.log import deprecated
+
+
 # TODO: This will be deprecated in v0.1
 
 
 class OVOSApiService:
-
+    @deprecated("This reference is deprecated. Import from ovos-backend-client")
     def __init__(self) -> None:
-        LOG.warning(f"ovos_utils.ovos_service_api is deprecated. "
-                    f"Import from ovos-backend-client")
         self.uuid_storage = JsonStorageXDG("ovos_api_uuid")
         self.token_storage = JsonStorageXDG("ovos_api_token")
 
@@ -178,9 +178,8 @@ class OvosOmdb:
 
 
 class OvosGeolocate:
+    @deprecated("This reference is deprecated. Import from ovos-backend-client")
     def __init__(self):
-        LOG.warning(f"This reference is deprecated. "
-                    f"Import from ovos-backend-client")
         pass
 
     def geolocate_ip(self, ip):

--- a/ovos_utils/ovos_service_api.py
+++ b/ovos_utils/ovos_service_api.py
@@ -7,7 +7,7 @@ from ovos_utils.log import deprecated
 
 
 class OVOSApiService:
-    @deprecated("Import from ovos-backend-client", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api", "0.1.0")
     def __init__(self) -> None:
         self.uuid_storage = JsonStorageXDG("ovos_api_uuid")
         self.token_storage = JsonStorageXDG("ovos_api_token")
@@ -44,7 +44,7 @@ class OVOSApiService:
 
 
 class OvosWeather:
-    @deprecated("Import from ovos-backend-client", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -96,7 +96,7 @@ class OvosWeather:
 
 
 class OvosWolframAlpha:
-    @deprecated("Import from ovos-backend-client", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -136,7 +136,7 @@ class OvosWolframAlpha:
 
 
 class OvosEdamamRecipe:
-    @deprecated("Import from ovos-backend-client", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -158,7 +158,7 @@ class OvosEdamamRecipe:
 
 
 class OvosOmdb:
-    @deprecated("Import from ovos-backend-client", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -182,7 +182,7 @@ class OvosOmdb:
 
 
 class OvosGeolocate:
-    @deprecated("Import from ovos-backend-client", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api", "0.1.0")
     def __init__(self):
         pass
 
@@ -206,7 +206,7 @@ class OvosGeolocate:
 
 
 class OvosSendMail:
-    @deprecated("Import from ovos-backend-client", "0.1.0")
+    @deprecated("Import from ovos-backend-client.api", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 

--- a/ovos_utils/ovos_service_api.py
+++ b/ovos_utils/ovos_service_api.py
@@ -7,7 +7,7 @@ from ovos_utils.log import deprecated
 
 
 class OVOSApiService:
-    @deprecated("This reference is deprecated. Import from ovos-backend-client")
+    @deprecated("Import from ovos-backend-client", "0.1.0")
     def __init__(self) -> None:
         self.uuid_storage = JsonStorageXDG("ovos_api_uuid")
         self.token_storage = JsonStorageXDG("ovos_api_token")
@@ -44,6 +44,7 @@ class OVOSApiService:
 
 
 class OvosWeather:
+    @deprecated("Import from ovos-backend-client", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -95,6 +96,7 @@ class OvosWeather:
 
 
 class OvosWolframAlpha:
+    @deprecated("Import from ovos-backend-client", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -134,6 +136,7 @@ class OvosWolframAlpha:
 
 
 class OvosEdamamRecipe:
+    @deprecated("Import from ovos-backend-client", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -155,6 +158,7 @@ class OvosEdamamRecipe:
 
 
 class OvosOmdb:
+    @deprecated("Import from ovos-backend-client", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 
@@ -178,7 +182,7 @@ class OvosOmdb:
 
 
 class OvosGeolocate:
-    @deprecated("This reference is deprecated. Import from ovos-backend-client")
+    @deprecated("Import from ovos-backend-client", "0.1.0")
     def __init__(self):
         pass
 
@@ -202,6 +206,7 @@ class OvosGeolocate:
 
 
 class OvosSendMail:
+    @deprecated("Import from ovos-backend-client", "0.1.0")
     def __init__(self):
         self.api = OVOSApiService()
 

--- a/ovos_utils/process_utils.py
+++ b/ovos_utils/process_utils.py
@@ -292,6 +292,7 @@ class PIDLock:  # python 3+ 'class Lock'
     """
     @classmethod
     def init(cls):
+        # TODO: Path to deprecation
         try:
             from ovos_config.meta import get_xdg_base
             base_dir = get_xdg_base()

--- a/ovos_utils/signal.py
+++ b/ovos_utils/signal.py
@@ -5,7 +5,7 @@ import os
 import os.path
 
 
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 
 
 def get_ipc_directory(domain=None, config=None):
@@ -23,6 +23,7 @@ def get_ipc_directory(domain=None, config=None):
         str: a path to the IPC directory
     """
     if config is None:
+        log_deprecation(f"Expected a dict config and got None.", "0.1.0")
         try:
             from ovos_config.config import read_mycroft_config
             config = read_mycroft_config()

--- a/ovos_utils/skills/__init__.py
+++ b/ovos_utils/skills/__init__.py
@@ -1,7 +1,7 @@
 from ovos_config.config import read_mycroft_config, update_mycroft_config
 from ovos_utils.messagebus import wait_for_reply
 from ovos_utils.skills.locations import get_default_skills_directory, get_installed_skill_ids
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 
 
 def get_non_properties(obj):
@@ -70,10 +70,9 @@ def whitelist_skill(skill, config=None):
     return False
 
 
+@deprecated("This method is deprecated. Skills are now loaded based on "
+            "`runtime_requirements`", "0.1.0")
 def make_priority_skill(skill, config=None):
-    # TODO: Deprecate in 0.1.0
-    LOG.warning("This method is deprecated. Skills are now loaded based on "
-                "`runtime_requirements`")
     # config = config or read_mycroft_config()
     # skills_config = config.get("skills", {})
     # priority_skills = skills_config.get("priority_skills", [])
@@ -89,13 +88,13 @@ def make_priority_skill(skill, config=None):
     return False
 
 
+@deprecated("This reference is deprecated, use "
+            "`ovos_utils.skills.locations.get_default_skill_dir", "0.1.0")
 def get_skills_folder(config=None):
-    LOG.warning("This reference is deprecated, use "
-                "`ovos_utils.skills.locations.get_default_skill_dir")
     return get_default_skills_directory(config)
 
 
+@deprecated("This reference is deprecated, use "
+            "`ovos_utils.skills.locations.get_installed_skill_ids", "0.1.0")
 def get_installed_skills(config=None):
-    LOG.warning("This reference is deprecated, use "
-                "`ovos_utils.skills.locations.get_installed_skill_ids")
     return get_installed_skill_ids(config)

--- a/ovos_utils/skills/audioservice.py
+++ b/ovos_utils/skills/audioservice.py
@@ -18,7 +18,7 @@ from datetime import timedelta
 # interface with the AudioService via messagebus outside core
 from os.path import abspath
 
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 from ovos_utils.messagebus import get_mycroft_bus, dig_for_message, \
     FakeMessage as Message
 
@@ -223,10 +223,10 @@ class AudioServiceInterface(ClassicAudioServiceInterface):
         bus: Mycroft messagebus connection
     """
 
+    @deprecated("AudioServiceInterface has been deprecated, compatibility "
+                "layer in use\nplease move to OCPInterface", "0.1.0")
     def __init__(self, bus=None):
         super().__init__(bus)
-        LOG.warning("AudioServiceInterface has been deprecated, compatibility layer in use\n"
-                    "please move to OCPInterface")
 
     @staticmethod
     def _uri2meta(uri):

--- a/ovos_utils/skills/locations.py
+++ b/ovos_utils/skills/locations.py
@@ -3,7 +3,7 @@ from os import makedirs, listdir
 from typing import List, Optional
 from ovos_config.config import read_mycroft_config
 from ovos_config.locations import get_xdg_data_save_path, get_xdg_data_dirs
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 
 
 def get_installed_skill_ids(conf: Optional[dict] = None) -> List[str]:
@@ -107,9 +107,9 @@ def get_default_skills_directory(conf: Optional[dict] = None) -> str:
 
     # if .conf wants to use a specific path, use it!
     if path_override:
-        LOG.warning("'directory_override' is deprecated!\n"
-                    "It will no longer be supported after version 0.0.3\n"
-                    "add the new path to 'extra_directories' instead")
+        log_deprecation("'directory_override' is deprecated!"
+                        "add the new path to 'extra_directories' instead",
+                        "0.1.0")
         skills_folder = expanduser(path_override)
     elif conf["skills"].get("extra_directories") and \
             len(conf["skills"].get("extra_directories")) > 0:

--- a/ovos_utils/skills/settings.py
+++ b/ovos_utils/skills/settings.py
@@ -2,7 +2,7 @@ import requests
 import json
 from os.path import join, expanduser, exists
 from json_database import JsonStorageXDG, JsonStorage
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, log_deprecation
 
 
 def settings2meta(settings, section_name="Skill Settings"):
@@ -93,7 +93,7 @@ def get_all_remote_settings(identity_file=None, backend_url=None):
 def get_local_settings(skill_dir, skill_name=None) -> dict:
     """Build a JsonStorage using the JSON string stored in settings.json."""
     if skill_name:
-        LOG.warning("skill_name is an unused legacy argument, will be removed in 0.0.3 or later")
+        log_deprecation("skill_name is an unused legacy argument", "0.1.0")
     if skill_dir.endswith("/settings.json"):
         settings_path = skill_dir
     else:

--- a/ovos_utils/sound/alsa.py
+++ b/ovos_utils/sound/alsa.py
@@ -2,16 +2,15 @@ try:
     import alsaaudio
 except ImportError:
     alsaaudio = None
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 
 
 class AlsaControl:
     _mixer = None
 
+    @deprecated("This class is deprecated! Controls moved to "
+                "ovos_phal_plugin_alsa.AlsaVolumeControlPlugin", "0.1.0")
     def __init__(self, control=None):
-        # TODO: Deprecate class in 0.1
-        LOG.warning(f"This class is deprecated! Controls moved to"
-                    f"ovos_phal_plugin_alsa.AlsaVolumeControlPlugin")
         if alsaaudio is None:
             LOG.error("pyalsaaudio not installed")
             LOG.info("Run pip install pyalsaaudio==0.8.2")

--- a/ovos_utils/sound/pulse.py
+++ b/ovos_utils/sound/pulse.py
@@ -1,17 +1,17 @@
 import subprocess
 import re
 import collections
-from ovos_utils.log import LOG
+from ovos_utils.log import LOG, deprecated
 
 
 class PulseAudio:
     volume_re = re.compile('^set-sink-volume ([^ ]+) (.*)')
     mute_re = re.compile('^set-sink-mute ([^ ]+) ((?:yes)|(?:no))')
 
+    @deprecated("This class is deprecated! Controls moved to "
+                "ovos_phal_plugin_pulseaudio.PulseAudioVolumeControlPlugin",
+                "0.1.0")
     def __init__(self):
-        # TODO: Deprecate class in 0.1
-        LOG.warning(f"This class is deprecated! Controls moved to"
-                    f"ovos_phal_plugin_pulseaudio.PulseAudioVolumeControlPlugin")
         self._mute = collections.OrderedDict()
         self._volume = collections.OrderedDict()
         self.update()

--- a/test/unittests/deprecation_helper.py
+++ b/test/unittests/deprecation_helper.py
@@ -1,6 +1,6 @@
 from ovos_utils.log import deprecated
 
 
-@deprecated("imported deprecation")
+@deprecated("imported deprecation", "0.1.0")
 def deprecated_function():
     pass

--- a/test/unittests/deprecation_helper.py
+++ b/test/unittests/deprecation_helper.py
@@ -1,0 +1,6 @@
+from ovos_utils.log import deprecated
+
+
+@deprecated("imported deprecation")
+def deprecated_function():
+    pass

--- a/test/unittests/test_events.py
+++ b/test/unittests/test_events.py
@@ -65,6 +65,10 @@ class TestEvents(unittest.TestCase):
         self.assertEqual(interface.events.bus, self.bus)
         self.assertEqual(interface.scheduled_repeats, list())
 
+        # Deprecated properties
+        self.assertEqual(interface.sched_id, interface.skill_id)
+        self.assertEqual(interface.name, interface.skill_id)
+
         now_time = datetime.datetime.now(datetime.timezone.utc)
         self.assertAlmostEqual(now_time.timestamp(), time(), 0)
         event_time_tzaware = now_time + datetime.timedelta(hours=1)

--- a/test/unittests/test_log.py
+++ b/test/unittests/test_log.py
@@ -74,11 +74,13 @@ class TestLog(unittest.TestCase):
         log_deprecation("test")
         create_logger.assert_called_once()
         log_msg = log_warning.call_args[0][0]
-        self.assertTrue(log_msg.startswith('test - unittest.mock'))
+        self.assertIn('version=Unknown', log_msg, log_msg)
+        self.assertIn('test', log_msg, log_msg)
 
         log_deprecation()
         log_msg = log_warning.call_args[0][0]
-        self.assertTrue(log_msg.startswith('DEPRECATED - unittest.mock'))
+        self.assertIn('version=Unknown', log_msg, log_msg)
+        self.assertIn('DEPRECATED', log_msg, log_msg)
 
     @patch("ovos_utils.log.LOG.create_logger")
     def test_deprecated_decorator(self, create_logger):
@@ -92,11 +94,13 @@ class TestLog(unittest.TestCase):
         deprecated_function()
         log_warning.assert_called_once()
         log_msg = log_warning.call_args[0][0]
-        self.assertTrue(log_msg.startswith('imported deprecation - test_log'))
+        self.assertIn('version=0.1.0', log_msg, log_msg)
+        self.assertIn('test_log:', log_msg, log_msg)
+        self.assertIn('imported deprecation', log_msg, log_msg)
 
         call_arg = None
 
-        @deprecated("test deprecation")
+        @deprecated("test deprecation", "1.0.0")
         def _deprecated_function(test_arg):
             nonlocal call_arg
             call_arg = test_arg
@@ -104,4 +108,5 @@ class TestLog(unittest.TestCase):
         _deprecated_function("test")
         self.assertEqual(call_arg, "test")
         log_msg = log_warning.call_args[0][0]
-        self.assertTrue(log_msg.startswith('test deprecation - '))
+        self.assertIn('version=1.0.0', log_msg, log_msg)
+        self.assertIn('test deprecation', log_msg, log_msg)

--- a/test/unittests/test_log.py
+++ b/test/unittests/test_log.py
@@ -4,7 +4,7 @@ import unittest
 import importlib
 
 from os.path import join, dirname, isdir, isfile
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 
 
 class TestLog(unittest.TestCase):
@@ -64,12 +64,15 @@ class TestLog(unittest.TestCase):
         from ovos_utils.log import init_service_logger
         # TODO
 
-    @patch("ovos_utils.log.LOG.warning")
-    def test_log_deprecation(self, log_warning):
+    @patch("ovos_utils.log.LOG.create_logger")
+    def test_log_deprecation(self, create_logger):
+        fake_log = Mock()
+        log_warning = fake_log.warning
+        create_logger.return_value = fake_log
         from ovos_utils.log import log_deprecation
 
         log_deprecation("test")
-        log_warning.assert_called_once()
+        create_logger.assert_called_once()
         log_msg = log_warning.call_args[0][0]
         self.assertTrue(log_msg.startswith('test - unittest.mock'))
 
@@ -77,8 +80,11 @@ class TestLog(unittest.TestCase):
         log_msg = log_warning.call_args[0][0]
         self.assertTrue(log_msg.startswith('DEPRECATED - unittest.mock'))
 
-    @patch("ovos_utils.log.LOG.warning")
-    def test_deprecated_decorator(self, log_warning):
+    @patch("ovos_utils.log.LOG.create_logger")
+    def test_deprecated_decorator(self, create_logger):
+        fake_log = Mock()
+        log_warning = fake_log.warning
+        create_logger.return_value = fake_log
         from ovos_utils.log import deprecated
         import sys
         sys.path.insert(0, dirname(__file__))


### PR DESCRIPTION
Adds a helper and decorator to mark methods or particular handling as deprecated. The log name is overridden to match the line where the decorator is defined and the decorated method to ensure decorated method logs are actionable.

Example deprecation log:
```
2023-06-12 16:10:17.952 - skills - ovos_utils.skills.settings:get_local_settings:96 - WARNING - Deprecation version=0.1.0. Caller=neon_utils.skills.mycroft_skill:73. skill_name is an unused legacy argument
```