### PR TITLE
Cleanup deprecation logs

### DIFF
--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -228,8 +228,12 @@ def deprecated(log_message: str, deprecation_version: str):
     def wrapped(func):
         @functools.wraps(func)
         def log_wrapper(*args, **kwargs):
+            if hasattr(func, "__self__"):
+                name = f"{func.__self__.__name__}.{func.__name__}"
+            else:
+                name = func.__name__
             log_deprecation(log_message=log_message,
-                            func_name=func.__name__,
+                            func_name=name,
                             func_module=func.__module__,
                             deprecation_version=deprecation_version)
             return func(*args, **kwargs)

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -10,6 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import functools
 import inspect
 import logging
 import os
@@ -175,6 +176,7 @@ def init_service_logger(service_name):
 def log_deprecation(log_message: str = "DEPRECATED",
                     deprecation_version: str = "Unknown",
                     func_name: str = None,
+                    func_module: str = None,
                     excluded_package_refs: List[str] = None):
     """
     Log a deprecation warning with information for the call outside the module
@@ -182,6 +184,7 @@ def log_deprecation(log_message: str = "DEPRECATED",
     @param log_message: Log contents describing the deprecation
     @param deprecation_version: package version in which method will be deprecated
     @param func_name: decorated function name (else read from stack)
+    @param func_module: decorated function module (else read from stack)
     @param excluded_package_refs: list of packages to exclude from call origin
         determination. i.e. an internal exception handling method should log the
         first call external to that package
@@ -189,7 +192,7 @@ def log_deprecation(log_message: str = "DEPRECATED",
     import inspect
     stack = inspect.stack()[1:]  # [0] is this method
     call_info = "Unknown Origin"
-    origin_module = None
+    origin_module = func_module
     log_name = LOG.name
     for call in stack:
         module = inspect.getmodule(call.frame)
@@ -221,9 +224,13 @@ def deprecated(log_message: str, deprecation_version: str):
     @param deprecation_version: package version in which deprecation will occur
     """
     def wrapped(func):
-        log_deprecation(log_message=log_message,
-                        func_name=func.__name__,
-                        deprecation_version=deprecation_version)
-        return func
+        @functools.wraps(func)
+        def log_wrapper(*args, **kwargs):
+            log_deprecation(log_message=log_message,
+                            func_name=func.__name__,
+                            func_module=func.__module__,
+                            deprecation_version=deprecation_version)
+            return func(*args, **kwargs)
+        return log_wrapper
 
     return wrapped

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -228,12 +228,8 @@ def deprecated(log_message: str, deprecation_version: str):
     def wrapped(func):
         @functools.wraps(func)
         def log_wrapper(*args, **kwargs):
-            if hasattr(func, "__self__"):
-                name = f"{func.__self__.__name__}.{func.__name__}"
-            else:
-                name = func.__name__
             log_deprecation(log_message=log_message,
-                            func_name=name,
+                            func_name=func.__qualname__,
                             func_module=func.__module__,
                             deprecation_version=deprecation_version)
             return func(*args, **kwargs)

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -202,9 +202,13 @@ def log_deprecation(log_message: str = "DEPRECATED",
             # Skip calls from this module and unittests to get at real origin
             continue
         if not origin_module:
+            # Assume first outside call is the origin if not specified
             origin_module = name
             log_name = f"{LOG.name} - {name}:{func_name or call[3]}:{call[2]}"
             continue
+        elif log_name == LOG.name and name == origin_module:
+            # Decorator provided origin module name, update the log name
+            log_name = f"{LOG.name} - {name}:{func_name or call[3]}:{call[2]}"
         if excluded_package_refs and any((name.startswith(x) for x in
                                           excluded_package_refs)):
             continue

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -193,7 +193,8 @@ def log_deprecation(log_message: str = "DEPRECATED",
     stack = inspect.stack()[1:]  # [0] is this method
     call_info = "Unknown Origin"
     origin_module = func_module
-    log_name = LOG.name
+    log_name = f"{LOG.name} - {func_module}:{func_name}" if \
+        func_module and func_name else LOG.name
     for call in stack:
         module = inspect.getmodule(call.frame)
         name = module.__name__ if module else call.filename
@@ -206,9 +207,6 @@ def log_deprecation(log_message: str = "DEPRECATED",
             origin_module = name
             log_name = f"{LOG.name} - {name}:{func_name or call[3]}:{call[2]}"
             continue
-        elif log_name == LOG.name:
-            # Decorator provided origin module name, update the log name
-            log_name = f"{LOG.name} - {name}:{func_name or call[3]}:{call[2]}"
         if excluded_package_refs and any((name.startswith(x) for x in
                                           excluded_package_refs)):
             continue

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -206,7 +206,7 @@ def log_deprecation(log_message: str = "DEPRECATED",
             origin_module = name
             log_name = f"{LOG.name} - {name}:{func_name or call[3]}:{call[2]}"
             continue
-        elif log_name == LOG.name and name == origin_module:
+        elif log_name == LOG.name:
             # Decorator provided origin module name, update the log name
             log_name = f"{LOG.name} - {name}:{func_name or call[3]}:{call[2]}"
         if excluded_package_refs and any((name.startswith(x) for x in

--- a/ovos_utils/skills/audioservice.py
+++ b/ovos_utils/skills/audioservice.py
@@ -224,7 +224,7 @@ class AudioServiceInterface(ClassicAudioServiceInterface):
     """
 
     @deprecated("AudioServiceInterface has been deprecated, compatibility "
-                "layer in use\nplease move to OCPInterface", "0.1.0")
+                "layer in use. please move to OCPInterface", "0.1.0")
     def __init__(self, bus=None):
         super().__init__(bus)
 

--- a/test/unittests/deprecation_helper.py
+++ b/test/unittests/deprecation_helper.py
@@ -4,3 +4,9 @@ from ovos_utils.log import deprecated
 @deprecated("imported deprecation", "0.1.0")
 def deprecated_function():
     pass
+
+
+class Deprecated:
+    @deprecated("Class Deprecated", "0.2.0")
+    def __init__(self):
+        pass

--- a/test/unittests/test_log.py
+++ b/test/unittests/test_log.py
@@ -90,13 +90,18 @@ class TestLog(unittest.TestCase):
         from ovos_utils.log import deprecated
         import sys
         sys.path.insert(0, dirname(__file__))
-        from deprecation_helper import deprecated_function
+        from deprecation_helper import deprecated_function, Deprecated
         deprecated_function()
         log_warning.assert_called_once()
         log_msg = log_warning.call_args[0][0]
         self.assertIn('version=0.1.0', log_msg, log_msg)
-        self.assertIn('test_log:', log_msg, log_msg)
+        self.assertIn('test_log', log_msg, log_msg)
         self.assertIn('imported deprecation', log_msg, log_msg)
+
+        test_class = Deprecated()
+        log_msg = log_warning.call_args[0][0]
+        self.assertIn('version=0.2.0', log_msg, log_msg)
+        self.assertIn('Class Deprecated', log_msg, log_msg)
 
         call_arg = None
 


### PR DESCRIPTION
Deprecation decorator was logging on import of deprecated methods. This adds handling to accurately log originating calls to deprecated methods without logging on import