### PR TITLE
Volunteer GUI upload on init

### DIFF
--- a/ovos_utils/gui.py
+++ b/ovos_utils/gui.py
@@ -647,6 +647,12 @@ class GUIInterface:
         if not self.ui_directories:
             LOG.debug("No UI resources to upload")
             return
+
+        requested_skill = message.data.get("skill_id") or self._skill_id
+        if requested_skill != self._skill_id:
+            # GUI requesting a specific skill to upload other than this one
+            return
+
         request_res_type = message.data.get("framework") or "all" if "all" in \
             self.ui_directories else "qt5"
         # Note that ui_directory "all" is a special case that will upload all

--- a/ovos_utils/gui.py
+++ b/ovos_utils/gui.py
@@ -556,6 +556,11 @@ class GUIInterface:
         if bus:
             self.set_bus(bus)
 
+        if self.ui_directories:
+            self.bus.emit(Message("gui.volunteer_page_upload",
+                                  {'skill_id': skill_id},
+                                  {'source': skill_id, "destination": ["gui"]}))
+
     @property
     def remote_url(self) -> Optional[str]:
         """Returns configuration value for url of remote-server."""

--- a/test/unittests/test_gui.py
+++ b/test/unittests/test_gui.py
@@ -100,6 +100,10 @@ class TestGuiInterface(unittest.TestCase):
     ui_base_dir = join(dirname(__file__), "test_ui")
     ui_dirs = {'qt5': join(ui_base_dir, 'ui')}
     iface_name = "test_interface"
+
+    volunteered_upload = Mock()
+    bus.on('gui.volunteer_page_upload', volunteered_upload)
+
     interface = GUIInterface(iface_name, bus, None, config, ui_dirs)
 
     def test_00_gui_interface_init(self):
@@ -111,6 +115,9 @@ class TestGuiInterface(unittest.TestCase):
         self.assertEqual(self.interface.skill_id, self.iface_name)
         self.assertIsNone(self.interface.page)
         self.assertIsInstance(self.interface.connected, bool)
+        self.volunteered_upload.assert_called_once()
+        upload_message = self.volunteered_upload.call_args[0][0]
+        self.assertEqual(upload_message.data["skill_id"], self.iface_name)
 
     def test_build_message_type(self):
         name = "test"
@@ -138,7 +145,7 @@ class TestGuiInterface(unittest.TestCase):
         # Upload default/legacy behavior (qt5 `ui` dir)
         message = Message('test', {}, {'context': "Test"})
         self.interface.upload_gui_pages(message)
-        self.assertTrue(handled.wait(10))
+        self.assertTrue(handled.wait(2))
 
         self.assertEqual(msg.context['context'], message.context['context'])
         self.assertEqual(msg.msg_type, "gui.page.upload")
@@ -164,7 +171,7 @@ class TestGuiInterface(unittest.TestCase):
                                                     'test_ui', 'gui')
         message = Message('test', {"framework": "all"}, {'context': "All"})
         self.interface.upload_gui_pages(message)
-        self.assertTrue(handled.wait(10))
+        self.assertTrue(handled.wait(2))
 
         self.assertEqual(msg.context['context'], message.context['context'])
         self.assertEqual(msg.msg_type, "gui.page.upload")
@@ -180,6 +187,13 @@ class TestGuiInterface(unittest.TestCase):
                          b"qt5", pages)
         self.assertEqual(bytes.fromhex(pages.get("qt6/test.qml")),
                          b"qt6", pages)
+
+        # Upload requested other skill
+        handled.clear()
+        message = Message('test', {"framework": "all",
+                                   "skill_id": "other_skill"})
+        self.interface.upload_gui_pages(message)
+        self.assertFalse(handled.wait(2))
 
     def test_register_handler(self):
         # TODO

--- a/test/unittests/test_gui.py
+++ b/test/unittests/test_gui.py
@@ -119,6 +119,10 @@ class TestGuiInterface(unittest.TestCase):
         upload_message = self.volunteered_upload.call_args[0][0]
         self.assertEqual(upload_message.data["skill_id"], self.iface_name)
 
+        # Test GUI init with no ui directories
+        self.GUIInterface("no_ui_dirs_gui", self.bus, None, self.config)
+        self.volunteered_upload.assert_called_once_with(upload_message)
+
     def test_build_message_type(self):
         name = "test"
         self.assertEqual(self.interface.build_message_type(name),


### PR DESCRIPTION
Adds message emit on interface init to notify GUI when resources are available to upload
Adds handling in `upload_gui_pages` to skip requests for specific skills other than this one