### PR TITLE
fix/scheduled_event message.context

### DIFF
--- a/ovos_utils/events.py
+++ b/ovos_utils/events.py
@@ -297,8 +297,9 @@ class EventSchedulerInterface:
                       'data': data}
 
         message = self._get_source_message()
-        self.bus.emit(message.reply('mycroft.scheduler.schedule_event',
-                                    data=event_data, context=context))
+        context = context or message.context
+        self.bus.emit(Message('mycroft.scheduler.schedule_event',
+                              data=event_data, context=context))
 
     def schedule_event(self, handler: Callable[[Optional[Message]], None],
                        when: Union[datetime, int, float],

--- a/ovos_utils/events.py
+++ b/ovos_utils/events.py
@@ -298,6 +298,7 @@ class EventSchedulerInterface:
 
         message = self._get_source_message()
         context = context or message.context
+        context["skill_id"] = self.skill_id
         self.bus.emit(Message('mycroft.scheduler.schedule_event',
                               data=event_data, context=context))
 


### PR DESCRIPTION
wrongly using .reply caused wrong source/destination when the event triggered

symptoms include self.speak used in a scheduled event not being spoken

diagnosed with https://github.com/OpenVoiceOS/ovos-core/pull/374