### PR TITLE
OCP serialization

### DIFF
--- a/ovos_utils/ocp.py
+++ b/ovos_utils/ocp.py
@@ -293,7 +293,7 @@ class Playlist(list):
             "match_confidence": self.match_confidence,
             "skill_id": self.skill_id,
             "skill_icon": self.skill_icon,
-            "playlist": [e.as_dict for e in self]
+            "playlist": [e.as_dict for e in self.entries]
         }
         return data
 


### PR DESCRIPTION
improves the serialization and deserialization of the OCP objects

makes them compatible with the dicts currently returned by OCP skills, paving the way to allow those skills to return these objects directly in a future workshop release