### PR TITLE
feat: mac support for ram cache

### DIFF
--- a/ovos_utils/file_utils.py
+++ b/ovos_utils/file_utils.py
@@ -5,6 +5,7 @@ import re
 import tempfile
 from os import walk
 from os.path import dirname, splitext, join
+from sys import platform
 from threading import RLock
 from typing import Optional, List
 
@@ -56,12 +57,12 @@ def get_temp_path(*args) -> str:
 def get_cache_directory(folder: str) -> str:
     """
     Get a temporary cache directory, preferably in RAM.
-    Note that Windows will not use RAM.
+    Note that only Linux use RAM.
     @param folder: base path to use for cache
     @return: valid cache path
     """
     path = get_temp_path(folder)
-    if os.name != 'nt':
+    if platform == 'linux':
         try:
             from memory_tempfile import MemoryTempfile
             path = join(MemoryTempfile(fallback=True).gettempdir(), folder)


### PR DESCRIPTION
Currently, the behavior of the RAM temp cache is to check for a `posix` result from `os.name`. Mac OS is a posix-based OS but the library in use only supports Linux. So, this PR makes it so the tempfile is only created if the OS is detected as Linux.

Not a hard requirement for Mac support but it gets rid of an annoying traceback. :)
