### PR TITLE
deprecate/signal utils

### DIFF
--- a/ovos_utils/file_utils.py
+++ b/ovos_utils/file_utils.py
@@ -16,6 +16,36 @@ from ovos_utils.bracket_expansion import expand_options
 from ovos_utils.log import LOG, log_deprecation
 
 
+def ensure_directory_exists(directory, domain=None):
+    """ Create a directory and give access rights to all
+
+    Args:
+        domain (str): The IPC domain.  Basically a subdirectory to prevent
+            overlapping signal filenames.
+
+    Returns:
+        str: a path to the directory
+    """
+    if domain:
+        directory = os.path.join(directory, domain)
+
+    # Expand and normalize the path
+    directory = os.path.normpath(directory)
+    directory = os.path.expanduser(directory)
+
+    if not os.path.isdir(directory):
+        try:
+            save = os.umask(0)
+            os.makedirs(directory, 0o777)  # give everyone rights to r/w here
+        except OSError:
+            LOG.warning("Failed to create: " + directory)
+            pass
+        finally:
+            os.umask(save)
+
+    return directory
+
+
 def to_alnum(skill_id: str) -> str:
     """
     Convert a skill id to only alphanumeric characters

--- a/ovos_utils/process_utils.py
+++ b/ovos_utils/process_utils.py
@@ -17,8 +17,6 @@ import sys
 from collections import namedtuple
 from dataclasses import dataclass
 from enum import IntEnum
-from signal import signal, SIGKILL, SIGINT, SIGTERM, \
-    SIG_DFL, default_int_handler, SIG_IGN  # signals
 from threading import Event
 from time import sleep, monotonic
 
@@ -251,6 +249,9 @@ class Signal:
         func:  User supplied function that will act as the new signal handler.
         """
         super(Signal, self).__init__()  # python 3+ 'super().__init__()
+
+        from signal import signal, SIG_DFL, default_int_handler, SIG_IGN
+
         self.__sig_value = sig_value
         self.__user_func = func  # store user passed function
         self.__previous_func = signal(sig_value, self)
@@ -278,6 +279,8 @@ class Signal:
         Class destructor.  Called during garbage collection.
         Resets the signal handler to the previous function.
         """
+
+        from signal import signal
         signal(self.__sig_value, self.__previous_func)
 
 
@@ -330,6 +333,7 @@ class PIDLock:  # python 3+ 'class Lock'
         """
         Trap both SIGINT and SIGTERM to gracefully clean up PID files
         """
+        from signal import SIGINT, SIGTERM
         self.__handlers = {SIGINT: Signal(SIGINT, self.delete),
                            SIGTERM: Signal(SIGTERM, self.delete)}
 
@@ -348,7 +352,8 @@ class PIDLock:  # python 3+ 'class Lock'
         if not os.path.isfile(self.path):
             return
         with open(self.path, 'r') as L:
-            try:
+            try: # TODO - make it work in windows ?
+                from signal import SIGKILL
                 os.kill(int(L.read()), SIGKILL)
             except Exception as e:
                 LOG.error(f"Failed to kill PID {L}: {e}")
@@ -402,4 +407,5 @@ def reset_sigint_handler():
     This fixes KeyboardInterrupt not getting raised when started via
     start-mycroft.sh
     """
+    from signal import signal, SIGINT, default_int_handler
     signal(SIGINT, default_int_handler)

--- a/ovos_utils/signal.py
+++ b/ovos_utils/signal.py
@@ -3,9 +3,10 @@ import os.path
 import tempfile
 import time
 
-from ovos_utils.log import LOG, log_deprecation
+from ovos_utils.log import LOG, log_deprecation, deprecated
 
 
+@deprecated("ovos_utils.signal module has been deprecated!", "0.2.0")
 def get_ipc_directory(domain=None, config=None):
     """Get the directory used for Inter Process Communication
 
@@ -23,8 +24,8 @@ def get_ipc_directory(domain=None, config=None):
     if config is None:
         log_deprecation(f"Expected a dict config and got None.", "0.1.0")
         try:
-            from ovos_config.config import read_mycroft_config
-            config = read_mycroft_config()
+            from ovos_config.config import Configuration
+            config = Configuration()
         except ImportError:
             LOG.warning("Config not provided and ovos_config not available")
             config = dict()
@@ -35,6 +36,7 @@ def get_ipc_directory(domain=None, config=None):
     return ensure_directory_exists(path, domain)
 
 
+@deprecated("use 'from ovos_utils.file_utils import ensure_directory_exists' instead", "0.2.0")
 def ensure_directory_exists(directory, domain=None):
     """ Create a directory and give access rights to all
 
@@ -45,26 +47,11 @@ def ensure_directory_exists(directory, domain=None):
     Returns:
         str: a path to the directory
     """
-    if domain:
-        directory = os.path.join(directory, domain)
-
-    # Expand and normalize the path
-    directory = os.path.normpath(directory)
-    directory = os.path.expanduser(directory)
-
-    if not os.path.isdir(directory):
-        try:
-            save = os.umask(0)
-            os.makedirs(directory, 0o777)  # give everyone rights to r/w here
-        except OSError:
-            LOG.warning("Failed to create: " + directory)
-            pass
-        finally:
-            os.umask(save)
-
-    return directory
+    from ovos_utils.file_utils import ensure_directory_exists as _ede
+    return _ede(directory, domain)
 
 
+@deprecated("ovos_utils.signal module has been deprecated!", "0.2.0")
 def create_file(filename):
     """ Create the file filename and create any directories needed
 
@@ -79,6 +66,7 @@ def create_file(filename):
         f.write('')
 
 
+@deprecated("ovos_utils.signal module has been deprecated!", "0.2.0")
 def create_signal(signal_name, config=None):
     """Create a named signal
 
@@ -96,6 +84,7 @@ def create_signal(signal_name, config=None):
         return False
 
 
+@deprecated("ovos_utils.signal module has been deprecated!", "0.2.0")
 def check_for_signal(signal_name, sec_lifetime=0, config=None):
     """See if a named signal exists
 


### PR DESCRIPTION
we already deprecated usage of this everywhere in ovos, only the utils remain

in some circumstances, depending on workdir, python also gets confused with importing signal, as it tries to use the relative import for ovos_utils.signal, imports moved to where they are used to minimize this impact

this also allows process_utils.py to be imported under windows as reported by @mikejgray