### PR TITLE
fix/log_level_cfg

### DIFF
--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -104,7 +104,8 @@ class LOG:
         cls.base_path = config.get("path") or xdg_path
         cls.max_bytes = config.get("max_bytes", 50000000)
         cls.backup_count = config.get("backup_count", 3)
-        cls.level = config.get("level") or LOG.level
+        level = config.get("level") or LOG.level
+        cls.set_level(level)
         cls.diagnostic_mode = config.get("diagnostic", False)
 
     @classmethod

--- a/ovos_utils/log.py
+++ b/ovos_utils/log.py
@@ -12,6 +12,7 @@
 #
 import functools
 import inspect
+import json
 import logging
 import os
 import sys
@@ -193,8 +194,9 @@ class LOG:
 
 def _monitor_log_level():
     _logs_conf = get_logs_config(LOG.name)
-    if hash(_logs_conf) != _monitor_log_level.config_hash:
-        _monitor_log_level.config_hash = hash(_logs_conf)
+    hax = hash(json.dumps(_logs_conf, sort_keys=True, indent=2))
+    if hax != _monitor_log_level.config_hash:
+        _monitor_log_level.config_hash = hax
         LOG.init(_logs_conf)
         LOG.info("updated LOG level")
 
@@ -204,7 +206,7 @@ _monitor_log_level.config_hash = None
 
 def init_service_logger(service_name):
     _logs_conf = get_logs_config(service_name)
-    _monitor_log_level.config_hash = hash(_logs_conf)
+    _monitor_log_level.config_hash = hash(json.dumps(_logs_conf, sort_keys=True, indent=2))
     LOG.name = service_name
     LOG.init(_logs_conf)  # setup the LOG instance
     try:


### PR DESCRIPTION
react to changes in log level from mycroft.conf

closes https://github.com/OpenVoiceOS/ovos-config/issues/125

to test change level between info and debug, and confirm in services that it is respected

```javascript
  "logging": {
    "log_level": "DEBUG"
  },
```

```
(NOTICE debug log)
-06-19 00:12:02.968 - skills - ovos_config.config:_on_file_change:312 - DEBUG - Calling 1 callbacks
2024-06-19 00:12:02.970 - skills - ovos_utils.log:_monitor_log_level:202 - INFO - updated LOG level

(NOTICE only INFO afterwards)

2024-06-19 00:12:08.765 - skills - padacioso:calc_intent:240 - INFO - No match
2024-06-19 00:12:08.768 - skills - ovos_core.intent_services.commonqa_service:match:109 - INFO - Gathering answers from skills: ['ovos-skill-fakewiki.openvoiceos']
2024-06-19 00:12:08.776 - skills - ovos_core.intent_services.ocp_service:is_ocp_query:1113 - INFO - OVOSCommonPlay prediction: OCP confidence: 0.944
2024-06-19 00:12:08.789 - skills - ovos_core.intent_services.ocp_service:classify_media:1086 - INFO - OVOSCommonPlay MediaType prediction: music confidence: 0.638
2024-06-19 00:12:17.783 - skills - ovos_config.config:_on_file_change:311 - INFO - /home/miro/.config/mycroft/mycroft.conf changed on disk
2024-06-19 00:12:17.787 - skills - ovos_utils.log:_monitor_log_level:202 - INFO - updated LOG level

(NOTICE debug logs again)

2024-06-19 00:12:22.319 - skills - ovos_core.transformers:transform:64 - DEBUG - ovos-utterance-cancel: {}
2024-06-19 00:12:22.321 - skills - ovos_core.transformers:transform:64 - DEBUG - ovos-utterance-normalizer: {'lang': 'en-us'}
```