### PR TITLE
fix:long description

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def required(requirements_file):
         return [pkg for pkg in requirements
                 if pkg.strip() and not pkg.startswith("#")]
 
-with open("README.md", "r") as f:
+with open(BASEDIR + "/README.md", "r") as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
needs absolute path to readme file

fixes automation failures when reading version from setup.py to get tag name