### PR TITLE
fix: remove mycroft-bus-client compat

### DIFF
--- a/ovos_utils/events.py
+++ b/ovos_utils/events.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from inspect import signature
 from typing import Callable, Optional, Union
 
-from ovos_utils.fakebus import Message, FakeBus, dig_for_message
+from ovos_utils.fakebus import FakeMessage as Message, FakeBus, dig_for_message
 from ovos_utils.file_utils import to_alnum
 from ovos_utils.log import LOG
 

--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -173,12 +173,6 @@ class _MutableMessage(type):
                 return True
         except ImportError:
             pass
-        try:
-            from mycroft_bus_client.message import Message as _MycroftMessage
-            if isinstance(instance, _MycroftMessage):
-                return True
-        except ImportError:
-            pass
         return super().__instancecheck__(instance)
 
 
@@ -192,11 +186,6 @@ class FakeMessage(metaclass=_MutableMessage):
             return _M(*args, **kwargs)
         except ImportError:
             pass
-        try:  # some old install that upgraded during migration period
-            from mycroft_bus_client import Message as _M
-            return _M(*args, **kwargs)
-        except ImportError:  # FakeMessage
-            return super().__new__(cls)
 
     def __init__(self, msg_type, data=None, context=None):
         """Used to construct a message object
@@ -339,9 +328,3 @@ class FakeMessage(metaclass=_MutableMessage):
 
         return FakeMessage(msg_type, data, context=new_context)
 
-
-class Message(FakeMessage):
-    def __int__(self, *args, **kwargs):
-        log_deprecation(f"Import from ovos_bus_client.message directly",
-                        "0.1.0")
-        FakeMessage.__init__(self, *args, **kwargs)

--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -186,6 +186,8 @@ class FakeMessage(metaclass=_MutableMessage):
             return _M(*args, **kwargs)
         except ImportError:
             pass
+        return super().__new__(cls)
+
 
     def __init__(self, msg_type, data=None, context=None):
         """Used to construct a message object

--- a/ovos_utils/fakebus.py
+++ b/ovos_utils/fakebus.py
@@ -60,7 +60,7 @@ class FakeBus:
             message = args[0]
         else:
             message = args[1]
-        parsed_message = Message.deserialize(message)
+        parsed_message = FakeMessage.deserialize(message)
         try:  # replicate side effects
             from ovos_bus_client.session import Session, SessionManager
             sess = Session.from_message(parsed_message)

--- a/ovos_utils/messagebus.py
+++ b/ovos_utils/messagebus.py
@@ -1,1 +1,0 @@
-from ovos_utils.fakebus import dig_for_message, FakeMessage, Message, FakeBus

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -10,7 +10,7 @@ except (ImportError, ModuleNotFoundError):
     from pyee.executor import ExecutorEventEmitter
 
 from unittest.mock import MagicMock, patch
-from ovos_utils.messagebus import FakeBus
+from ovos_utils.fakebus import FakeBus
 from ovos_bus_client.util.scheduler import EventScheduler, EventSchedulerInterface
 
 

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -116,4 +116,4 @@ class TestEventSchedulerInterface(unittest.TestCase):
         es.shutdown()
         # Check that the reference to the function has been removed from the
         # bus emitter
-        self.assertTrue(len(es.bus._events.get('id:f', [])) == 0)
+        self.assertTrue(len(es.bus.ee._events.get('id:f', [])) == 0)

--- a/test/unittests/test_event_scheduler.py
+++ b/test/unittests/test_event_scheduler.py
@@ -4,11 +4,6 @@
 
 import unittest
 import time
-try:
-    from pyee import ExecutorEventEmitter
-except (ImportError, ModuleNotFoundError):
-    from pyee.executor import ExecutorEventEmitter
-
 from unittest.mock import MagicMock, patch
 from ovos_utils.fakebus import FakeBus
 from ovos_bus_client.util.scheduler import EventScheduler, EventSchedulerInterface
@@ -110,8 +105,6 @@ class TestEventSchedulerInterface(unittest.TestCase):
         def f(message):
             print('TEST FUNC')
 
-        bus = ExecutorEventEmitter()
-
         es = EventSchedulerInterface('tester')
         es.set_bus(FakeBus())
         es.set_id('id')
@@ -123,4 +116,4 @@ class TestEventSchedulerInterface(unittest.TestCase):
         es.shutdown()
         # Check that the reference to the function has been removed from the
         # bus emitter
-        self.assertTrue(len(bus._events.get('id:f', [])) == 0)
+        self.assertTrue(len(es.bus._events.get('id:f', [])) == 0)

--- a/test/unittests/test_events.py
+++ b/test/unittests/test_events.py
@@ -7,7 +7,7 @@ from threading import Event
 from time import time
 from unittest.mock import Mock
 
-from ovos_utils.fakebus import FakeBus, Message
+from ovos_utils.fakebus import FakeBus, FakeMessage as Message
 
 
 class TestEvents(unittest.TestCase):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Streamlined message handling by consolidating dependencies on `ovos_bus_client`.
	- Enhanced reliability by removing legacy support for `mycroft_bus_client`.

- **Bug Fixes**
	- Simplified the `__instancecheck__` method to improve performance.

- **Refactor**
	- Updated the `FakeMessage` class to eliminate unnecessary fallbacks and deprecated warnings.
	- Renamed the imported message class for consistency across event handling functionalities.
	- Adjusted type annotations in event handling methods to reflect the new message class.
	- Updated test cases to align with the new message handling structure.
	- Streamlined imports in the event scheduler tests for improved clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->