### PR TITLE
fix: restore backwards compat

### DIFF
--- a/ovos_utils/messagebus.py
+++ b/ovos_utils/messagebus.py
@@ -1,0 +1,12 @@
+from ovos_utils.fakebus import dig_for_message, FakeMessage, FakeBus
+from ovos_utils.log import log_deprecation
+
+
+log_deprecation("ovos_utils.messagebus has been deprecated since version 0.1.0!! "
+                "please import from ovos_utils.fakebus or ovos_bus_client directly", "1.0.0")
+
+
+class Message(FakeMessage):
+  """just for compat, stuff in the wild importing from here even with deprecation warnings..."""
+  
+  


### PR DESCRIPTION
removed in #304 

the previous deprecation warning was never reached when ovos-bus-client was available, some places never migrated and there are still imports in the wild

restore the old import with a proper deprecation log for now
