### PR TITLE
refactor:move_to_extras

### DIFF
--- a/ovos_utils/geolocation.py
+++ b/ovos_utils/geolocation.py
@@ -2,7 +2,6 @@ from typing import Dict, Any, Optional
 
 import requests
 from requests.exceptions import RequestException, Timeout
-from timezonefinder import TimezoneFinder
 
 from ovos_utils import timed_lru_cache
 from ovos_utils.lang import standardize_lang_tag
@@ -10,7 +9,7 @@ from ovos_utils.log import LOG
 from ovos_utils.network_utils import get_external_ip, is_valid_ip
 
 
-_tz_finder: TimezoneFinder = None
+_tz_finder = None
 
 
 def get_timezone(lat: float, lon: float) -> Dict[str, str]:
@@ -30,6 +29,7 @@ def get_timezone(lat: float, lon: float) -> Dict[str, str]:
     """
     global _tz_finder
     if _tz_finder is None:
+        from timezonefinder import TimezoneFinder
         # lazy loaded, resource intensive so we only want to do it once
         _tz_finder = TimezoneFinder()
     try:

--- a/ovos_utils/gui.py
+++ b/ovos_utils/gui.py
@@ -34,13 +34,7 @@ def is_gui_running(applications: List[str] = _default_gui_apps) -> bool:
     Return true if a GUI application is running
     @param applications: list of applications to check for
     """
-    deprecated = any((is_process_running(app) for app in applications
-                      if app.startswith("mycroft-")))
-    if deprecated:
-        LOG.warning("you are running a deprecated mycroft-gui version, "
-                    "please move to a OVOS maintained version")
-        return True
-    return deprecated or any((is_process_running(app) for app in applications))
+    return any((is_process_running(app) for app in applications))
 
 
 def is_gui_connected(bus=None) -> bool:

--- a/ovos_utils/lang/__init__.py
+++ b/ovos_utils/lang/__init__.py
@@ -2,14 +2,13 @@ from os import listdir
 from os.path import isdir, join
 from typing import Optional
 
-from langcodes import tag_distance, standardize_tag as std
-
 from ovos_utils.file_utils import resolve_resource_file
 
 
 def standardize_lang_tag(lang_code: str, macro=True) -> str:
     """https://langcodes-hickford.readthedocs.io/en/sphinx/index.html"""
     try:
+        from langcodes import standardize_tag as std
         return str(std(lang_code, macro=macro))
     except:
         if macro:
@@ -28,6 +27,7 @@ def get_language_dir(base_path: str, lang: str ="en-US") -> Optional[str]:
     for f in listdir(base_path):
         if isdir(f"{base_path}/{f}"):
             try:
+                from langcodes import tag_distance
                 score = tag_distance(lang, f)
             except:  # not a valid language code
                 continue

--- a/ovos_utils/oauth.py
+++ b/ovos_utils/oauth.py
@@ -2,7 +2,6 @@ import time
 
 import requests
 from json_database import JsonStorageXDG
-from oauthlib.oauth2 import WebApplicationClient
 from ovos_config.locations import get_xdg_cache_save_path
 
 from ovos_utils.log import LOG
@@ -108,6 +107,7 @@ def refresh_oauth_token(token_id):
     client_secret = app_data["client_secret"]
 
     # Perform refresh
+    from oauthlib.oauth2 import WebApplicationClient
     client = WebApplicationClient(client_id, refresh_token=refresh_token)
     uri, headers, body = client.prepare_refresh_token_request(token_endpoint)
     refresh_result = requests.post(uri, headers=headers, data=body,

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -3,3 +3,6 @@ ovos-plugin-manager>=0.0.25,<1.0.0
 ovos-config>=0.0.12,<2.0.0
 ovos-workshop>=0.0.13,<3.0.0
 ovos_bus_client>=0.0.8,<2.0.0
+langcodes
+timezonefinder
+oauthlib~=3.2

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,6 +8,3 @@ combo-lock~=0.2
 rich-click~=1.7
 rich~=13.7
 orjson
-langcodes
-timezonefinder
-oauthlib~=3.2


### PR DESCRIPTION
package is too bloated for basic usage, timezonefinder, langcodes and oauth dependencies have been moved to extras