### PR TITLE
feat: extend dialog/intent templates

### DIFF
--- a/ovos_utils/bracket_expansion.py
+++ b/ovos_utils/bracket_expansion.py
@@ -1,6 +1,6 @@
 import itertools
 import re
-from typing import List
+from typing import List, Dict
 
 from ovos_utils.log import deprecated
 
@@ -21,18 +21,27 @@ def expand_template(template: str) -> List[str]:
                 parts.append([segment])
         return itertools.product(*parts)
 
+    def fully_expand(texts):
+        """Iteratively expand alternatives until all possibilities are covered."""
+        result = set(texts)
+        while True:
+            expanded = set()
+            for text in result:
+                options = list(expand_alternatives(text))
+                expanded.update(["".join(option).strip() for option in options])
+            if expanded == result:  # No new expansions found
+                break
+            result = expanded
+        return sorted(result)  # Return a sorted list for consistency
+
     # Expand optional items first
     template = expand_optional(template)
 
-    # Expand all combinations of alternatives
-    options = expand_alternatives(template)
-
-    # Join parts into full sentences
-    expanded_sentences = ["".join(option).strip() for option in options]
-    return expanded_sentences
+    # Fully expand all combinations of alternatives
+    return fully_expand([template])
 
 
-def expand_slots(template: str, slots: dict[str, list[str]]) -> list[str]:
+def expand_slots(template: str, slots: Dict[str, List[str]]) -> List[str]:
     """Expand a template by first expanding alternatives and optional components,
     then substituting slot placeholders with their corresponding options.
 

--- a/ovos_utils/dialog.py
+++ b/ovos_utils/dialog.py
@@ -5,7 +5,7 @@ from os.path import join
 from pathlib import Path
 from typing import Optional
 
-from ovos_utils.bracket_expansion import expand_options
+from ovos_utils.bracket_expansion import expand_template
 from ovos_utils.file_utils import resolve_resource_file
 from ovos_utils.lang import translate_word
 from ovos_utils.log import LOG, log_deprecation
@@ -92,7 +92,7 @@ class MustacheDialogRenderer:
             line = template_functions[index % len(template_functions)]
         # Replace {key} in line with matching values from context
         line = line.format(**context)
-        line = random.choice(expand_options(line))
+        line = random.choice(expand_template(line))
 
         # Here's where we keep track of what we've said recently. Remember,
         # this is by line in the .dialog file, not by exact phrase

--- a/ovos_utils/file_utils.py
+++ b/ovos_utils/file_utils.py
@@ -12,7 +12,7 @@ from typing import Optional, List
 from watchdog.events import FileSystemEventHandler
 from watchdog.observers import Observer
 
-from ovos_utils.bracket_expansion import expand_options
+from ovos_utils.bracket_expansion import expand_template
 from ovos_utils.log import LOG, log_deprecation
 
 
@@ -241,7 +241,7 @@ def read_vocab_file(path: str) -> List[List[str]]:
         for line in voc_file.readlines():
             if line.startswith('#') or line.strip() == '':
                 continue
-            vocab.append(expand_options(line.lower()))
+            vocab.append(expand_template(line.lower()))
     return vocab
 
 

--- a/test/unittests/test_bracket_expansion.py
+++ b/test/unittests/test_bracket_expansion.py
@@ -1,31 +1,118 @@
 import unittest
 
+from ovos_utils.bracket_expansion import expand_template, expand_slots
 
-class TestBracketExpansion(unittest.TestCase):
-    def test_expand_parentheses(self):
-        from ovos_utils.bracket_expansion import expand_parentheses
-        # TODO
 
-    def test_expand_options(self):
-        from ovos_utils.bracket_expansion import expand_options
-        # TODO
+class TestTemplateExpansion(unittest.TestCase):
 
-    def test_fragment(self):
-        from ovos_utils.bracket_expansion import Fragment
-        # TODO
+    def test_expand_slots(self):
+        # Test for expanding slots
+        template = "change [the ]brightness to {brightness_level} and color to {color_name}"
+        slots = {
+            "brightness_level": ["low", "medium", "high"],
+            "color_name": ["red", "green", "blue"]
+        }
 
-    def test_word(self):
-        from ovos_utils.bracket_expansion import Word
-        # TODO
+        expanded_sentences = expand_slots(template, slots)
 
-    def test_sentence(self):
-        from ovos_utils.bracket_expansion import Sentence
-        # TODO
+        expected_sentences = ['change brightness to low and color to red',
+                              'change brightness to low and color to green',
+                              'change brightness to low and color to blue',
+                              'change brightness to medium and color to red',
+                              'change brightness to medium and color to green',
+                              'change brightness to medium and color to blue',
+                              'change brightness to high and color to red',
+                              'change brightness to high and color to green',
+                              'change brightness to high and color to blue',
+                              'change the brightness to low and color to red',
+                              'change the brightness to low and color to green',
+                              'change the brightness to low and color to blue',
+                              'change the brightness to medium and color to red',
+                              'change the brightness to medium and color to green',
+                              'change the brightness to medium and color to blue',
+                              'change the brightness to high and color to red',
+                              'change the brightness to high and color to green',
+                              'change the brightness to high and color to blue']
+        self.assertEqual(expanded_sentences, expected_sentences)
 
-    def test_options(self):
-        from ovos_utils.bracket_expansion import Options
-        # TODO
+    def test_expand_template(self):
+        # Test for template expansion
+        templates = [
+            "[hello,] (call me|my name is) {name}",
+            "Expand (alternative|choices) into a list of choices.",
+            "sentences have [optional] words ",
+            "alternative words can be (used|written)",
+            "sentence[s] can have (pre|suf)fixes mid word too",
+            "do( the | )thing(s|) (old|with) style and( no | )spaces",
+            "[(this|that) is optional]",
+            "tell me a [{joke_type}] joke",
+            "play {query} [in ({device_name}|{skill_name}|{zone_name})]"
+        ]
 
-    def test_sentence_tree_parser(self):
-        from ovos_utils.bracket_expansion import SentenceTreeParser
-        # TODO
+        expected_outputs = {
+            "[hello,] (call me|my name is) {name}": [
+                "call me {name}",
+                "hello, call me {name}",
+                "hello, my name is {name}",
+                "my name is {name}"
+            ],
+            "Expand (alternative|choices) into a list of choices.": [
+                "Expand alternative into a list of choices.",
+                "Expand choices into a list of choices."
+            ],
+            "sentences have [optional] words ": [
+                "sentences have  words",
+                "sentences have optional words"
+            ],
+            "alternative words can be (used|written)": [
+                "alternative words can be used",
+                "alternative words can be written"
+            ],
+            "sentence[s] can have (pre|suf)fixes mid word too": [
+                "sentence can have prefixes mid word too",
+                "sentence can have suffixes mid word too",
+                "sentences can have prefixes mid word too",
+                "sentences can have suffixes mid word too"
+            ],
+            "do( the | )thing(s|) (old|with) style and( no | )spaces": [
+                "do the thing old style and no spaces",
+                "do the thing old style and spaces",
+                "do the thing with style and no spaces",
+                "do the thing with style and spaces",
+                "do the things old style and no spaces",
+                "do the things old style and spaces",
+                "do the things with style and no spaces",
+                "do the things with style and spaces",
+                "do thing old style and no spaces",
+                "do thing old style and spaces",
+                "do thing with style and no spaces",
+                "do thing with style and spaces",
+                "do things old style and no spaces",
+                "do things old style and spaces",
+                "do things with style and no spaces",
+                "do things with style and spaces"
+            ],
+            "[(this|that) is optional]": [
+                '',
+                'that is optional',
+                'this is optional'],
+            "tell me a [{joke_type}] joke": [
+                "tell me a  joke",
+                "tell me a {joke_type} joke"
+            ],
+            "play {query} [in ({device_name}|{skill_name}|{zone_name})]": [
+                "play {query}",
+                "play {query} in {device_name}",
+                "play {query} in {skill_name}",
+                "play {query} in {zone_name}"
+            ]
+        }
+
+        for template, expected_sentences in expected_outputs.items():
+            with self.subTest(template=template):
+                expanded_sentences = expand_template(template)
+                self.assertEqual(expanded_sentences, expected_sentences)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
closes #312

```python
templates = [
    "[hello,] (call me|my name is) {name}",
    "Expand (alternative|choices) into a list of choices.",
    "sentences have [optional] words ",
    "alternative words can be (used|written)",
    "sentence[s] can have (pre|suf)fixes mid word too",
    "do( the | )thing(s|) (old|with) style and( no | )spaces",
    "[(this|that) is optional]",
    "tell me a [{joke_type}] joke",
    "play {query} [in ({device_name}|{skill_name}|{zone_name})]"
]
for template in templates:
    print("###", template)
    expanded_sentences = expand_template(template)
    for sentence in expanded_sentences:
        print("-", sentence)
    # ### [hello,] (call me|my name is) {name}
    # - call me {name}
    # - hello, call me {name}
    # - hello, my name is {name}
    # - my name is {name}
    # ### Expand (alternative|choices) into a list of choices.
    # - Expand alternative into a list of choices.
    # - Expand choices into a list of choices.
    # ### sentences have [optional] words
    # - sentences have  words
    # - sentences have optional words
    # ### alternative words can be (used|written)
    # - alternative words can be used
    # - alternative words can be written
    # ### sentence[s] can have (pre|suf)fixes mid word too
    # - sentence can have prefixes mid word too
    # - sentence can have suffixes mid word too
    # - sentences can have prefixes mid word too
    # - sentences can have suffixes mid word too
    # ### do( the | )thing(s|) (old|with) style and( no | )spaces
    # - do the thing old style and no spaces
    # - do the thing old style and spaces
    # - do the thing with style and no spaces
    # - do the thing with style and spaces
    # - do the things old style and no spaces
    # - do the things old style and spaces
    # - do the things with style and no spaces
    # - do the things with style and spaces
    # - do thing old style and no spaces
    # - do thing old style and spaces
    # - do thing with style and no spaces
    # - do thing with style and spaces
    # - do things old style and no spaces
    # - do things old style and spaces
    # - do things with style and no spaces
    # - do things with style and spaces
    # ### [(this|that) is optional]
    # -
    # - that is optional
    # - this is optional
    # ### tell me a [{joke_type}] joke
    # - tell me a  joke
    # - tell me a {joke_type} joke
    # ### play {query} [in ({device_name}|{skill_name}|{zone_name})]
    # - play {query}
    # - play {query} in {device_name}
    # - play {query} in {skill_name}
    # - play {query} in {zone_name}

```

also adds a new util if we want to generate text from .intent + .entity combinations

```python
template = "change [the ]brightness to {brightness_level} and color to {color_name}"
slots = {
    "brightness_level": ["low", "medium", "high"],
    "color_name": ["red", "green", "blue"]
}

expanded_sentences = expand_slots(template, slots)
for sentence in expanded_sentences:
    print(sentence)
    # change the brightness to low and color to red
    # change the brightness to low and color to green
    # change the brightness to low and color to blue
    # change the brightness to medium and color to red
    # change the brightness to medium and color to green
    # change the brightness to medium and color to blue
    # change the brightness to high and color to red
    # change the brightness to high and color to green
    # change the brightness to high and color to blue
    # change brightness to low and color to red
    # change brightness to low and color to green
    # change brightness to low and color to blue
    # change brightness to medium and color to red
    # change brightness to medium and color to green
    # change brightness to medium and color to blue
    # change brightness to high and color to red
    # change brightness to high and color to green
    # change brightness to high and color to blue
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced `expand_template` function for enhanced template string processing.
	- Added `expand_slots` function to substitute placeholders with slot options.

- **Deprecated Features**
	- Marked several functions and class constructors as deprecated, advising users to transition to the new `expand_template` method for sentence expansion tasks.

- **Bug Fixes**
	- Updated dialog rendering to utilize the new `expand_template` method instead of the deprecated `expand_options`.

- **Testing Improvements**
	- Updated test suite to reflect the broader focus on template expansion, including new tests for `expand_template` and `expand_slots`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->